### PR TITLE
Link instructions on setting up Docker in the FAQ

### DIFF
--- a/Tools/Sailfish_SDK/FAQ/README.md
+++ b/Tools/Sailfish_SDK/FAQ/README.md
@@ -179,6 +179,10 @@ Should you need to continue using CRLF line endings for your project files, it i
 
 ## Docker
 
+### How can I set up Docker for use with Sailfish SDK?
+
+Please find the instructions on the [Sailfish SDK Installation](/Tools/Sailfish_SDK/Installation) page.
+
 ### I just upgraded my SDK, how can I switch to the Docker-based build engine?
 
 Build engine selection is only possible during fresh Sailfish SDK installation. You need to reinstall.


### PR DESCRIPTION
The FAQ entry was there before and moved to the Installation page just recently. It is still referenced by the SDK Installer, so adding it back.