### PR TITLE
Add repo command and patch error clarifications to Xperia 10 III build page

### DIFF
--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
@@ -52,7 +52,11 @@ git clone --recurse-submodules https://github.com/mer-hybris/droid-hal-sony-$FAM
 
 git config --global user.name "Your Name"
 git config --global user.email "you@example.com"
+```
 
+You'll need to ensure you have the `repo` command from the AOSP source code repositories installed. See the [Android Source instructions](https://source.android.com/setup/develop#installing-repo) for how to install it. Once available you can continue:
+
+```nosh
 # To save space, you can add "--depth=1 -c" flags to repo init:
 repo init -u git://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-localbuild.xml
 # Adjust X to bandwidth capabilities
@@ -141,6 +145,7 @@ cd $ANDROID_ROOT/hybris/mw
 D=droid-system-$VENDOR-template
 git clone --recursive https://github.com/mer-hybris/$D
 cd $D
+# The following command will throw up patch errors for `init.wod.rc`, `ld.config.28.txt` and `ld.config.29.txt`. These are to be expected and can be ignored.
 sudo droid-system-device/helpers/copy_tree.sh $ANDROID_SYSPART-mnt-system/system $ANDROID_SYSPART-mnt-vendor/vendor rpm/droid-system-$HABUILD_DEVICE.spec
 sudo chown -R $USER .
 # You can commit the changes, but before you push them out, make sure:


### PR DESCRIPTION
When following these instructions I hit some practical issues:

1. Couldn't gain `sudo` in the Ubuntu Chroot.
2. `repo` command missing.
3. Failed build dependency `pkgconfig(audiosystem-passthrough)`.
4. Errors when applying patches.
5. Missing commands for building droid-hal etc.

I've added some suggested changes for working around the errors or explaining that the errors can be ignored.