### PR TITLE
Fix kernel build of Xperia adaptations

### DIFF
--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_10_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_10_Build_and_Flash/README.md
@@ -44,7 +44,7 @@ Follow through the **chapter 4** until the end, and **ignore chapter 5**, instea
 ```nosh
 HABUILD_SDK $
 
-sudo apt-get install libssl-dev
+sudo apt-get install cpio libssl-dev
 sudo mkdir -p $ANDROID_ROOT
 sudo chown -R $USER $ANDROID_ROOT
 cd $ANDROID_ROOT
@@ -65,7 +65,7 @@ source build/envsetup.sh
 export USE_CCACHE=1
 lunch aosp_$DEVICE-user
 cd kernel/sony/msm-4.14/common-kernel
-./build-kernels-clang.sh -d $HABUILD_DEVICE -O $ANDROID_ROOT/out/target/product/$HABUILD_DEVICE/obj/kernel
+./build-kernels-clang.sh -d $HABUILD_DEVICE -O $ANDROID_ROOT/out/target/product/$HABUILD_DEVICE/obj/kernel || echo ERROR: kernel build failed, please inspect the log file
 # FIXME after this is merged: https://github.com/sonyxperiadev/kernel-sony-msm-4.14-common/pull/14
 cp dtbo-$HABUILD_DEVICE.img $ANDROID_ROOT/out/target/product/$HABUILD_DEVICE/dtbo.img
 cd -

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
@@ -44,7 +44,7 @@ Follow through the **chapter 4** until the end, and **ignore chapter 5**, instea
 ```nosh
 HABUILD_SDK $
 
-sudo apt-get install libssl-dev
+sudo apt-get install cpio libssl-dev
 sudo mkdir -p $ANDROID_ROOT
 sudo chown -R $USER $ANDROID_ROOT
 cd $ANDROID_ROOT
@@ -70,7 +70,7 @@ source build/envsetup.sh
 export USE_CCACHE=1
 lunch aosp_$DEVICE-user
 cd kernel/sony/msm-4.19/common-kernel
-./build-kernels-clang.sh -d $HABUILD_DEVICE -O $ANDROID_ROOT/out/target/product/$HABUILD_DEVICE/obj/kernel
+./build-kernels-clang.sh -d $HABUILD_DEVICE -O $ANDROID_ROOT/out/target/product/$HABUILD_DEVICE/obj/kernel || echo ERROR: kernel build failed, please inspect the log file
 # FIXME after this is merged and reapplied: https://github.com/sonyxperiadev/kernel-sony-msm-4.14-common/pull/14
 cp dtbo-$HABUILD_DEVICE.img $ANDROID_ROOT/out/target/product/$HABUILD_DEVICE/dtbo.img
 cd -

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_8_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_8_Build_and_Flash/README.md
@@ -53,7 +53,7 @@ At this point, install Android's repo tool: <https://source.android.com/source/d
 ```nosh
 HABUILD_SDK $
 
-sudo apt-get install libssl-dev
+sudo apt-get install cpio libssl-dev
 sudo mkdir -p $ANDROID_ROOT
 sudo chown -R $USER $ANDROID_ROOT
 cd $ANDROID_ROOT

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_9_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_9_Build_and_Flash/README.md
@@ -49,7 +49,7 @@ At this point, install Android's repo tool: <https://source.android.com/source/d
 ```nosh
 HABUILD_SDK $
 
-sudo apt-get install libssl-dev
+sudo apt-get install cpio libssl-dev
 sudo mkdir -p $ANDROID_ROOT
 sudo chown -R $USER $ANDROID_ROOT
 cd $ANDROID_ROOT


### PR DESCRIPTION
cpio is needed when building kernel under Android 10 and 11 env.

Also inform the user when kernel build fails.