### PR TITLE
Instruct to use .bash_profile instead of .mersdk.profile

### DIFF
--- a/Tools/Platform_SDK/Installation/README.md
+++ b/Tools/Platform_SDK/Installation/README.md
@@ -20,8 +20,10 @@ sudo mkdir -p $PLATFORM_SDK_ROOT/sdks/sfossdk
 sudo tar --numeric-owner -p -xjf Jolla-latest-SailfishOS_Platform_SDK_Chroot-i486.tar.bz2 -C $PLATFORM_SDK_ROOT/sdks/sfossdk
 echo "export PLATFORM_SDK_ROOT=$PLATFORM_SDK_ROOT" >> ~/.bashrc
 echo 'alias sfossdk=$PLATFORM_SDK_ROOT/sdks/sfossdk/sdk-chroot' >> ~/.bashrc; exec bash
-echo 'PS1="PlatformSDK $PS1"' > ~/.mersdk.profile
-echo '[ -d /etc/bash_completion.d ] && for i in /etc/bash_completion.d/*;do . $i;done' >> ~/.mersdk.profile
+echo 'if [[ $SAILFISH_SDK ]]; then' >> ~/.bash_profile
+echo '  PS1="PlatformSDK $PS1"' >> ~/.bash_profile
+echo '  [ -d /etc/bash_completion.d ] && for i in /etc/bash_completion.d/*;do . $i;done' >> ~/.bash_profile
+echo 'fi' >> ~/.bash_profile
 sfossdk
 ```
 
@@ -102,15 +104,17 @@ As mentioned, the Sailfish Platform SDK is location independent so it uses the l
 
 ## Entering Sailfish Platform SDK
 
-Before entering the Sailfish Platform SDK you may want to make an Sailfish Platform SDK equivalent of ".profile" to give you a nice prompt to remind you that you are in the Sailfish Platform SDK. This also reads the bash autocompletion scripts from inside the chroot.
+Before entering the Sailfish Platform SDK you may want to make changes to your ".bash_profile" file to give you a nice prompt to remind you that you are in the Sailfish Platform SDK. This also reads the bash autocompletion scripts from inside the chroot.
 ```nosh
-cat << EOF >> ~/.mersdk.profile
-PS1="PlatformSDK \$PS1"
-if [ -d /etc/bash_completion.d ]; then
-   for i in /etc/bash_completion.d/*;
-   do
+cat << EOF >> ~/.bash_profile
+if [[ $SAILFISH_SDK ]]; then
+  PS1="PlatformSDK \$PS1"
+  if [ -d /etc/bash_completion.d ]; then
+    for i in /etc/bash_completion.d/*;
+    do
       . \$i
-   done
+    done
+  fi
 fi
 EOF
 ```


### PR DESCRIPTION
There is no need to have a SDK specific initialisation file, as we can utilize the environment variable for SDK detection. JB#56751