### PR TITLE
Move logging instructions from Browser page

### DIFF
--- a/Reference/Core_Areas_and_APIs/Browser/Working_with_Browser/README.md
+++ b/Reference/Core_Areas_and_APIs/Browser/Working_with_Browser/README.md
@@ -26,16 +26,20 @@ EMBED_CONSOLE=1 sailfish-browser
 
 ### Enabling module log output
 
-  - Environment variable MOZ_LOG (esr52 onwards) can be used to enable various module logs
+  - Environment variable MOZ_LOG is used to enable logging for various modules
   - A comma separated list with verbosity
   - Verbosity levels are: 0 = Disabled, 1 = Error, 2 = Warnings, 3 = Info, 4 = Debug, 5 = Verbose
   - EmbedLite and EmbedLiteTrace are log components of embedlite
-  - Grep is your friend when trying to find the correct module if you're not aware of those (LazyLogModule)
+  - There is no option to turn all logging on, so explicit module names must be found in the source (grep for LazyLogModule).
   - For instance "Layers" can be used to analyze problems related to composited layers
   - Example
 ```nosh
 MOZ_LOG="AudioStream:5,MediaFormatReader:5,MediaSource:5" sailfish-browser youtube.com
 ```
+  - Useful module names
+    - nsComponentManager - Component loading and unloading
+    - GMP - Gecko Media Plugin activity
+    - PlatformDecoderModule - system codecs such as ffmpeg
 
 ## Debugging User-Agent problems
 


### PR DESCRIPTION
This commit moves logging instructions from Browser page to here.