### PR TITLE
Remove ChangeLog from Sailfsh X Android build and flash, update OEM blobs mentioned

### DIFF
--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_10_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_10_Build_and_Flash/README.md
@@ -10,9 +10,6 @@ nav_order: 500
 
 Here you will find instructions how to build Sailfish OS image and flash it to Sony Xperia 10 II device, which can be used as reference to port any other Sony Xperia Open Device that has Android 10 support.
 
-## ChangeLog
-
-  - 2021-02-12: Published as technical guidance for Android 10 64bit ARM adaptations
 
 ## Building
 

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
@@ -10,9 +10,6 @@ nav_order: 600
 
 Here you will find instructions how to build Sailfish OS image and flash it to Sony Xperia 10 III device, which can be used as reference to port any other Sony Xperia Open Device that has Android 11 support.
 
-## ChangeLog
-
-  - 2021-12-13: Published as technical guidance for Android 11 64bit ARM adaptations
 
 ## Building
 

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
@@ -222,7 +222,7 @@ fastboot flash boot_a boot.img
 fastboot flash dtbo_a dtbo.img
 fastboot flash product_a product.img
 fastboot flash recovery_a recovery.img
-fastboot flash oem SW_binaries_for_Xperia_Android_11_4.19_v8a_lena.img
+fastboot flash oem SW_binaries_for_Xperia_Android_11_4.19_v9a_$FAMILY.img
 fastboot flash --disable-verity --disable-verification vbmeta_a vbmeta.img
 fastboot flash --disable-verity --disable-verification vbmeta_system_a vbmeta_system.img
 fastboot flash vendor_a vendor.img


### PR DESCRIPTION
- Remove ChangeLog imported from the Wiki, the git history is much better for this
- Update OEM blob file for Android 11 based AOSP flash instructions, V9a based binaries are out and already used everywhere else.