### PR TITLE
Switch GitHub links from git protocol to https

### DIFF
--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_10_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_10_Build_and_Flash/README.md
@@ -58,7 +58,7 @@ You'll need to ensure you have the `repo` command from the AOSP source code repo
 
 ```nosh
 # To save space, you can add "--depth=1 -c" flags to repo init:
-repo init -u git://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-localbuild.xml
+repo init -u https://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-localbuild.xml
 # Adjust X to bandwidth capabilities
 repo sync -jX --fetch-submodules
 git clone --recurse-submodules https://github.com/mer-hybris/droid-src-sony droid-src -b "hybris-"$HAVERSION
@@ -116,7 +116,7 @@ sudo mkdir -p $ANDROID_ROOT-syspart
 sudo chown -R $USER $ANDROID_ROOT-syspart
 cd $ANDROID_ROOT-syspart
 # if you plan to contribute to syspart (/system partition), remove "--depth=1" and "-c" flags below
-repo init -u git://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-manifest.xml --depth=1
+repo init -u https://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-manifest.xml --depth=1
 # Adjust X to bandwidth capabilities
 repo sync -jX --fetch-submodules -c
 ln -s rpm/patches .

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
@@ -58,7 +58,7 @@ You'll need to ensure you have the `repo` command from the AOSP source code repo
 
 ```nosh
 # To save space, you can add "--depth=1 -c" flags to repo init:
-repo init -u git://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-localbuild.xml
+repo init -u https://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-localbuild.xml
 # Adjust X to bandwidth capabilities
 repo sync -jX
 git clone --recurse-submodules https://github.com/mer-hybris/droid-src-sony droid-src -b "hybris-"$HAVERSION
@@ -122,7 +122,7 @@ sudo mkdir -p $ANDROID_SYSPART
 sudo chown -R $USER $ANDROID_SYSPART
 cd $ANDROID_SYSPART
 # If you plan to contribute to syspart (/system partition), remove the "--depth=1 -c" flags below
-repo init -u git://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-manifest.xml --depth=1 -c
+repo init -u https://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-manifest.xml --depth=1 -c
 # Adjust X to bandwidth capabilities
 repo sync -jX --fetch-submodules
 ln -s rpm/patches .

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_6_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_6_Build_and_Flash/README.md
@@ -65,7 +65,7 @@ HABUILD_SDK $
 sudo mkdir -p $ANDROID_ROOT
 sudo chown -R $USER $ANDROID_ROOT
 cd $ANDROID_ROOT
-repo init -u git://github.com/mer-hybris/android.git -b hybris-$HAVERSION -m tagged-manifest.xml
+repo init -u https://github.com/mer-hybris/android.git -b hybris-$HAVERSION -m tagged-manifest.xml
 # Adjust X to your bandwidth capabilities
 repo sync -jX --fetch-submodules
 source build/envsetup.sh
@@ -107,7 +107,7 @@ sudo apt-get install rsync
 cd $ANDROID_ROOT/..
 mkdir syspart
 cd syspart
-repo init -u git://github.com/mer-hybris/android.git -b syspart-$HAVERSION -m tagged-manifest.xml
+repo init -u https://github.com/mer-hybris/android.git -b syspart-$HAVERSION -m tagged-manifest.xml
 # Adjust X to your bandwidth capabilities
 repo sync -jX --fetch-submodules
 source build/envsetup.sh

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_8_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_8_Build_and_Flash/README.md
@@ -57,7 +57,7 @@ sudo apt-get install cpio libssl-dev
 sudo mkdir -p $ANDROID_ROOT
 sudo chown -R $USER $ANDROID_ROOT
 cd $ANDROID_ROOT
-repo init -u git://github.com/mer-hybris/android.git -b hybris-$HAVERSION -m tagged-manifest.xml
+repo init -u https://github.com/mer-hybris/android.git -b hybris-$HAVERSION -m tagged-manifest.xml
 # Adjust X to your bandwidth capabilities
 repo sync -jX --fetch-submodules
 source build/envsetup.sh

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_9_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_9_Build_and_Flash/README.md
@@ -58,7 +58,7 @@ cd $ANDROID_ROOT
 git clone --recurse-submodules https://github.com/mer-hybris/droid-hal-sony-$FAMILY-$ANDROID_FLAVOUR .
 ln -s ../dhd rpm/
 mv rpm dhd-rpm
-repo init -u git://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-manifest.xml
+repo init -u https://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-manifest.xml
 # Adjust X to bandwidth capabilities
 repo sync -jX --fetch-submodules
 mv rpm droid-src
@@ -113,7 +113,7 @@ sudo mkdir -p $ANDROID_ROOT-syspart
 sudo chown -R $USER $ANDROID_ROOT-syspart
 cd $ANDROID_ROOT-syspart
 # if you plan to contribute to syspart (/system partition), remove "--depth=1" and "-c" flags below
-repo init -u git://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-manifest.xml --depth=1
+repo init -u https://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-manifest.xml --depth=1
 # Adjust X to bandwidth capabilities
 repo sync -jX --fetch-submodules -c
 ln -s rpm/patches .


### PR DESCRIPTION
Just hit this today:

```
HABUILD_SDK [j8210] me@zen:~/hadk$ repo init -u git://github.com/mer-hybris/android.git -b $HAVERSION -m tagged-localbuild.xml -c --depth=1
Downloading manifest from git://github.com/mer-hybris/android.git
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
manifests: sleeping 4.0 seconds before retrying
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
fatal: cannot obtain manifest git://github.com/mer-hybris/android.git
```

See:
https://github.blog/2021-09-01-improving-git-protocol-security-github/
