### PR TITLE
Clarification about word locally

### DIFF
--- a/Reference/Sailfish_OS_Cheat_Sheet/README.md
+++ b/Reference/Sailfish_OS_Cheat_Sheet/README.md
@@ -541,7 +541,7 @@ Import contacts from vCard
 devel-su -p vcardconverter contacts.vcf
 ```
 
-Export local contacts to vCard
+Export contacts stored in the phone memory to vCard
 ```nosh
 devel-su -p vcardconverter --export contacts.vcf
 ```

--- a/Reference/Sailfish_OS_Cheat_Sheet/README.md
+++ b/Reference/Sailfish_OS_Cheat_Sheet/README.md
@@ -541,7 +541,7 @@ Import contacts from vCard
 devel-su -p vcardconverter contacts.vcf
 ```
 
-Export contacts that are stored to the device internal memory to vCard
+Export contacts that are stored in the device internal memory to vCard
 ```nosh
 devel-su -p vcardconverter --export contacts.vcf
 ```

--- a/Reference/Sailfish_OS_Cheat_Sheet/README.md
+++ b/Reference/Sailfish_OS_Cheat_Sheet/README.md
@@ -541,7 +541,7 @@ Import contacts from vCard
 devel-su -p vcardconverter contacts.vcf
 ```
 
-Export contacts stored in the phone memory to vCard
+Export contacts that are stored to the device internal memory to vCard
 ```nosh
 devel-su -p vcardconverter --export contacts.vcf
 ```


### PR DESCRIPTION
Instead of using local, be more explicit.