### PR TITLE
Add "View page history" link to every page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -116,6 +116,8 @@ gh_edit_repository: "https://github.com/sailfishos/docs.sailfishos.org" # the gi
 gh_edit_branch: "master" # the branch that your docs is served from
 # gh_edit_source: docs # the source that your files originate from
 gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
+gh_edit_history_link: true # show or hide commit history link
+gh_edit_history_text: "View page history"
 
 # Color scheme currently only supports "dark", "light"/nil (default), or a custom scheme that you define
 color_scheme: sfos

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -175,7 +175,7 @@ layout: table_wrappers
         {% capture footer_custom %}
           {%- include footer_custom.html -%}
         {% endcapture %}
-        {% if footer_custom != "" or site.last_edit_timestamp or site.gh_edit_link %}
+        {% if footer_custom != "" or site.last_edit_timestamp or site.gh_edit_link or site.gh_edit_history_link %}
           <hr>
           <footer>
             {% if site.back_to_top %}
@@ -187,7 +187,7 @@ layout: table_wrappers
             {% if site.last_edit_timestamp or site.gh_edit_link %}
               <div class="d-flex mt-2">
                 {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
-                  <p class="text-small text-grey-dk-000 mb-0 mr-2">
+                  <p class="text-small text-grey-dk-000 mb-0 mr-4">
                     Page last modified: <span class="d-inline-block">{{ page.last_modified_date | date: site.last_edit_time_format }}</span>.
                   </p>
                 {% endif %}
@@ -198,8 +198,18 @@ layout: table_wrappers
                   site.gh_edit_branch and
                   site.gh_edit_view_mode
                 %}
-                  <p class="text-small text-grey-dk-000 mb-0">
+                  <p class="text-small text-grey-dk-000 mb-0 mr-4">
                     <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
+                  </p>
+                {% endif %}
+                {% if
+                  site.gh_edit_history_link and
+                  site.gh_edit_history_text and
+                  site.gh_edit_repository and
+                  site.gh_edit_branch
+                %}
+                  <p class="text-small text-grey-dk-000 mb-0">
+                    <a href="{{ site.gh_edit_repository }}/commits/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}/{{ page.path }}" id="page-history">{{ site.gh_edit_history_text }}</a>
                   </p>
                 {% endif %}
               </div>

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -96,10 +96,10 @@ layout: table_wrappers
 
             {{ footer_custom }}
 
-            {% if site.last_edit_timestamp or site.gh_edit_link %}
+            {% if site.last_edit_timestamp or site.gh_edit_link or site.gh_edit_history_link %}
               <div class="d-flex mt-2">
                 {% if site.last_edit_timestamp and site.last_edit_time_format and page.last_modified_date %}
-                  <p class="text-small text-grey-dk-000 mb-0 mr-2">
+                  <p class="text-small text-grey-dk-000 mb-0 mr-4">
                     Page last modified: <span class="d-inline-block">{{ page.last_modified_date | date: site.last_edit_time_format }}</span>.
                   </p>
                 {% endif %}
@@ -110,8 +110,18 @@ layout: table_wrappers
                   site.gh_edit_branch and
                   site.gh_edit_view_mode
                 %}
-                  <p class="text-small text-grey-dk-000 mb-0">
+                  <p class="text-small text-grey-dk-000 mb-0 mr-4">
                     <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
+                  </p>
+                {% endif %}
+                {% if
+                  site.gh_edit_history_link and
+                  site.gh_edit_history_text and
+                  site.gh_edit_repository and
+                  site.gh_edit_branch
+                %}
+                  <p class="text-small text-grey-dk-000 mb-0">
+                    <a href="{{ site.gh_edit_repository }}/commits/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}/{{ page.path }}" id="page-history">{{ site.gh_edit_history_text }}</a>
                   </p>
                 {% endif %}
               </div>


### PR DESCRIPTION
Adds a link to the bottom of each page, next to the "Edit this page on
GitHub" link, which links through to the github commit history. Can be
controlled using the _config.yml file.

See JB#57952