### PR TITLE
Don't remove sailfish-devicelock-fpd from droid-configs on local build

### DIFF
--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_10_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_10_Build_and_Flash/README.md
@@ -91,9 +91,6 @@ git clone --recursive https://github.com/mer-hybris/droid-config-sony-$FAMILY hy
 if [ -z "$(grep patterns-sailfish-consumer-generic $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-configuration-$DEVICE.inc)" ]; then
   sed -i "/Summary: Jolla Configuration $DEVICE/aRequires: patterns-sailfish-consumer-generic\n\n# Early stages of porting benefit from these:\nRequires: patterns-sailfish-device-tools" $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-configuration-$DEVICE.inc
 fi
-if [ -z "$(grep jolla-devicelock-daemon-encsfa $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-adaptation-$HABUILD_DEVICE.inc)" ]; then
-  sed -i "s/sailfish-devicelock-fpd/jolla-devicelock-daemon-encsfa/" $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-adaptation-$HABUILD_DEVICE.inc
-fi
 if [ "$(grep 'Requires: ofono-binder-plugin' $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-adaptation-$HABUILD_DEVICE.inc)" ]; then
   sed -i "s/ofono-binder-plugin/ofono-ril-binder-plugin/" $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-adaptation-$HABUILD_DEVICE.inc
 fi

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_10_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_10_Build_and_Flash/README.md
@@ -17,7 +17,7 @@ Please download the latest Sailfish OS HADK (Hardware Adaptation Development Kit
 
 Please check the requirements for your build host: <https://source.android.com/setup/build/requirements>
 
-Minimum Sailfish OS version for this port is 4.3.0.15.
+Minimum Sailfish OS version for this port is 4.4.0.58.
 
 If you are new to HADK, please carefully read the disclaimer on page 1, then **chapters 1 and 2**.
 
@@ -166,7 +166,7 @@ git clone --recursive https://github.com/mer-hybris/droid-hal-version-sony-$FAMI
 rpm/dhd/helpers/build_packages.sh --version
 
 # The next two variables are explained in chapter 8
-export RELEASE=4.3.0.15
+export RELEASE=4.4.0.58
 export EXTRA_NAME=-my1
 sudo zypper in lvm2 atruncate pigz android-tools
 cd $ANDROID_ROOT

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
@@ -91,9 +91,6 @@ git clone --recursive https://github.com/mer-hybris/droid-config-sony-$FAMILY hy
 if [ -z "$(grep patterns-sailfish-consumer-generic $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-configuration-$DEVICE.inc)" ]; then
   sed -i "/Summary: Jolla Configuration $DEVICE/aRequires: patterns-sailfish-consumer-generic\n\n# Early stages of porting benefit from these:\nRequires: patterns-sailfish-device-tools" $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-configuration-$DEVICE.inc
 fi
-if [ -z "$(grep jolla-devicelock-daemon-encsfa $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-adaptation-$HABUILD_DEVICE.inc)" ]; then
-  sed -i "s/sailfish-devicelock-fpd/jolla-devicelock-daemon-encsfa/" $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-adaptation-$HABUILD_DEVICE.inc
-fi
 # Clean out unavailable packages
 if [ -z "$(grep modem_auto_config $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-adaptation-$HABUILD_DEVICE.inc)" ]; then
   sed -i "/modem_auto_config/d" $ANDROID_ROOT/hybris/droid-configs/patterns/patterns-sailfish-device-adaptation-$HABUILD_DEVICE.inc

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
@@ -201,7 +201,7 @@ Feel free to help out in areas that you like.
 What works:
 
   - gps, bluetooth, wifi & internet sharing, mobile data, modem, camera, sensors, music/video playback
-  - fingerprint works (but is not available for the community build, however potential fix effort is ongoing for a release after 4.3.0)
+  - fingerprint works
   - USB networking
 
 Known issues:

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
@@ -17,7 +17,7 @@ Please download the latest Sailfish OS HADK (Hardware Adaptation Development Kit
 
 Please check the requirements for your build host: <https://source.android.com/setup/build/requirements>
 
-Minimum Sailfish OS version for this port is 4.3.0.15.
+Minimum Sailfish OS version for this port is 4.4.0.58.
 
 If you are new to HADK, please carefully read the disclaimer on page 1, then **chapters 1 and 2**.
 
@@ -179,7 +179,7 @@ git clone --recursive https://github.com/mer-hybris/droid-hal-version-sony-$FAMI
 rpm/dhd/helpers/build_packages.sh --version
 
 # The next two variables are explained in chapter 8
-export RELEASE=4.3.0.15
+export RELEASE=4.4.0.58
 export EXTRA_NAME=-my1
 sudo zypper in lvm2 atruncate pigz android-tools
 cd $ANDROID_ROOT

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_6_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_6_Build_and_Flash/README.md
@@ -30,7 +30,7 @@ Here you will find instructions how to build Sailfish OS image and flash it to S
 
 Please download the latest Sailfish OS HADK (Hardware Adaptation Development Kit) from within [this link](https://sailfishos.org/hadk).
 
-Minimum Sailfish OS version for this port is 4.3.0.15.
+Minimum Sailfish OS version for this port is 4.4.0.58.
 
 If you are new to HADK, please carefully read the disclaimer on page 1, then **chapters 1 and 2**.
 
@@ -148,7 +148,7 @@ Next, please proceed with:
 ```nosh
 PLATFORM_SDK $
 
-export RELEASE=4.3.0.15
+export RELEASE=4.4.0.58
 export EXTRA_NAME=-my1
 sudo zypper in lvm2 atruncate pigz
 sudo zypper in android-tools

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_8_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_8_Build_and_Flash/README.md
@@ -85,10 +85,6 @@ fi
 if [ -z "$(grep patterns-sailfish-consumer-generic $ANDROID_ROOT/hybris/droid-configs/patterns/jolla-configuration-$DEVICE.yaml)" ]; then
   sed -i "/Summary: Jolla Configuration $DEVICE/i- patterns-sailfish-consumer-generic\n- pattern:sailfish-porter-tools\n" $ANDROID_ROOT/hybris/droid-configs/patterns/jolla-configuration-$DEVICE.yaml
 fi
-if [ -z "$(grep jolla-devicelock-daemon-encsfa $ANDROID_ROOT/hybris/droid-configs/patterns/jolla-hw-adaptation-$HABUILD_DEVICE.yaml)" ]; then
-  sed -i "s/sailfish-devicelock-fpd/jolla-devicelock-daemon-encsfa/" $ANDROID_ROOT/hybris/droid-configs/patterns/jolla-hw-adaptation-$HABUILD_DEVICE.yaml
-  sed -i "/Obsoletes: jolla-devicelock-[a-z]*-encsfa/d" $ANDROID_ROOT/hybris/droid-configs/droid-config-common.inc
-fi
 rpm/dhd/helpers/build_packages.sh --configs
 rpm/dhd/helpers/build_packages.sh --mw # select "all" option when asked
 ```

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_8_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_8_Build_and_Flash/README.md
@@ -21,7 +21,7 @@ Here you will find instructions how to build Sailfish OS image and flash it to S
 
 Please download the latest Sailfish OS HADK (Hardware Adaptation Development Kit) from within [this link](https://sailfishos.org/hadk).
 
-Minimum Sailfish OS version for this port is 4.3.0.15.
+Minimum Sailfish OS version for this port is 4.4.0.58.
 
 If you are new to HADK, please carefully read the disclaimer on page 1, then **chapters 1 and 2**.
 
@@ -109,7 +109,7 @@ Next, please proceed with:
 ```nosh
 PLATFORM_SDK $
 
-export RELEASE=4.3.0.15
+export RELEASE=4.4.0.58
 export EXTRA_NAME=-my1
 sudo zypper in lvm2 atruncate pigz
 sudo zypper in android-tools

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_9_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_9_Build_and_Flash/README.md
@@ -93,9 +93,6 @@ fi
 if [ -z "$(grep patterns-sailfish-consumer-generic $ANDROID_ROOT/hybris/droid-configs/patterns/jolla-configuration-$DEVICE.yaml)" ]; then
   sed -i "/Summary: Jolla Configuration $DEVICE/i- patterns-sailfish-consumer-generic\n- pattern:sailfish-porter-tools\n" $ANDROID_ROOT/hybris/droid-configs/patterns/jolla-configuration-$DEVICE.yaml
 fi
-if [ -z "$(grep jolla-devicelock-daemon-encsfa $ANDROID_ROOT/hybris/droid-configs/patterns/jolla-hw-adaptation-$HABUILD_DEVICE.yaml)" ]; then
-  sed -i "s/sailfish-devicelock-fpd/jolla-devicelock-daemon-encsfa/" $ANDROID_ROOT/hybris/droid-configs/patterns/jolla-hw-adaptation-$HABUILD_DEVICE.yaml
-fi
 rpm/dhd/helpers/build_packages.sh --configs
 cd hybris/mw/libhybris
 git checkout master

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_9_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_9_Build_and_Flash/README.md
@@ -19,7 +19,7 @@ Here you will find instructions how to build Sailfish OS image and flash it to S
 
 Please download the latest Sailfish OS HADK (Hardware Adaptation Development Kit) from within [this link](https://sailfishos.org/hadk).
 
-Minimum Sailfish OS version for this port is 4.3.0.15.
+Minimum Sailfish OS version for this port is 4.4.0.58.
 
 If you are new to HADK, please carefully read the disclaimer on page 1, then **chapters 1 and 2**.
 
@@ -172,7 +172,7 @@ git clone --recursive https://github.com/mer-hybris/droid-hal-version-sony-$FAMI
 rpm/dhd/helpers/build_packages.sh --version
 
 # The next two variables are explained in chapter 8
-RELEASE=4.3.0.15
+RELEASE=4.4.0.58
 EXTRA_NAME=-my1
 sudo zypper in lvm2 atruncate pigz
 sudo zypper in android-tools


### PR DESCRIPTION
The dependencies for it namely sailfish-fpd-slave binder are now in
hw-common making sailfish-fpd also work for local builds.