### PR TITLE
Add a Known Issues section

### DIFF
--- a/Releases/Known_Issues/Koli/README.md
+++ b/Releases/Known_Issues/Koli/README.md
@@ -1,0 +1,76 @@
+---
+title: Sailfish OS 4.0.1.48 Known Issues
+permalink: Releases/Known_Issues/Koli/
+parent: Known Issues
+grand_parent: Releases
+layout: default
+nav_order: 500
+---
+
+This content can also be found in the [forum Release Notes](https://forum.sailfishos.org/t/release-notes-koli-4-0-1/4542#known-issues-generic-42).
+
+## Generic
+
+- *Assisted location service of Mozilla* has stopped working from 2020-03-01. This tends to slow down finding the position of the phone. We are looking for alternative ways to make it work faster. Unfortunately, this problem persists. It seems to affect Xperia XA2 worst.
+- Sailfish can connect *Bluetooth Low Energy devices*. However, Android apps cannot use peripheral devices via Bluetooth - other than for playback of the sound. Therefore smartwatches, for instance, cannot be controlled from Android apps, unfortunately.
+- *Signing in to Dropbox* works via Google only. So, after triggering the sign-in at "Settings > Accounts > Dropbox" and the browser page dropbox.com appears, tap "Sign in with Google" (if you have a Google account).
+- *Importing contacts wizard* fails to create a Google account in "Settings > Apps > People". The same happens if one tries to sign in to a Google account from Email. However, signing in to Google from "Settings > Accounts" does work correctly, after which the contacts will be downloaded to the device (if you allowed this in the account settings) 
+- An invalid warning and request to *uninstall all system packages* will appear if the previous OS version 3.4.0 is flashed to a device without installing the default Sailfish apps, followed by the download of the current OS version 4.0.1. This warning looks scary but it is just a warning. It should be okay to continue downloading and installing the OS update in the normal manner, i.e., you can ignore the warning. To avoid the warning, enabling the developer mode and running <code> devel-su; pkcon refresh</code> before downloading 4.0.1 may prevent the warning from appearing.
+- [ *developers only* ] connman-test package is broken (does not install) for devices freshly flashed with 4.0.1, because dbus-python is no longer available (requires python2). All still works if updating from 3.4.0 as in this case the old dbus-python (if it exists in rootfs) will be used.
+- *QR code reader* can recognise only the 2-dimensional code that has squares in 3 corners (for positioning).
+- 4.0.1 update will remove your *synced contacts* - please re-sync your accounts to get them back! So, go to Settings > Accounts, long-tap an account and take 'Sync'. Repeat to all of applicable accounts. Check People app, then. Also, restart your phone to see the contacts in Phone > People.*
+- *Calendar app* does not open anymore if user cancels first permission query and tries to reopen the app. Remedy: Restart phone, open Calendar, accept permissions. Fixed to the next OS release.
+- *Call recorder* does not save the conversation to the phone storage. This can be fixed with the following commands (and in the next OS release) - make sure you type the whole long command on the 2nd row:
+```
+        devel-su
+        echo -e '\nmkdir     ${PRIVILEGED}/Phone\nprivileged-data Phone' >> /etc/sailjail/permissions/Phone.permission 
+        systemctl-user restart voicecall-ui-prestart
+```
+
+## Known issues to Android App Support 9 - Xperia 10 & Xperia XA2
+
+- Aptoide Store (the default Android Store on Sailfish) may not become visible in the app grid if installed during startup wizard (SUW) or later in first boot. Remedy: reboot, uninstall it, install it again.
+- Aptoide Store app (of Jolla Store) is failing to install apps. In the end of the download an ERROR is shown and the installation attempt stops here. Please, download the latest Aptoide app ( `aptoide-latest.apk` ) from **[here](https://en.aptoide.com/download?package_uname=aptoide&entry_point=appstore_home_installer_mobile)** and install to your phone. We will update Jolla Store soon.
+- [APKPure website](https://m.apkpure.com/), which is another good source of Android apps, started serving 64bit APKs by default and they'll fail to install, but there won't be anything displayed to a user (because notifications from Android App Support are broken). You will need to choose armeabi-v7a (32bit) variant of the APK on the website.
+- Android apps cannot use peripheral devices via Bluetooth - other than for playback of the sound. Therefore smartwatches, for instance, cannot be controlled from Android apps.
+- The voice of an incoming call might not automatically be routed to a wired headset. However, if the user first directs the voice to the HF speaker and then back to the headset, the voice can be heard at the headset.
+
+## Known issues specific to Xperia X [no changes here]
+
+- Not implemented features: FM radio, double-tap wakeup, step counter, RTC Alarms
+- Issues with mobile data persist on some SIM cards. Turn the Flight mode on and off to reset the network setup. Reverting the device to Android and re-installing Sailfish X has often helped. See our [support article](https://jolla.zendesk.com/hc/en-us/articles/115004283713).
+- [camera] Force autofocus mode for photos, and continuous for video. After this, camera focus is still not ideal - as the camera stays out of focus when it starts until you either tap or try to take a shot - but the pictures seem to be better focused now
+- Bluetooth: problems with some car equipment, some audio devices and computers may appear
+- The loudspeaker volume level cannot be adjusted very high
+- Not all SD cards are recognized and mounted.
+
+## Known issues specific to Xperia XA2 [no changes here]
+
+- Not implemented features: FM radio, double-tap wakeup, RTC Alarms
+- Bluetooth: there are problems in connecting to some peripheral devices
+- XA2 does not power up when alarm time has elapsed
+- Flashing Sailfish X to XA2 might still fail (so far seen to happen on Ubuntu 18.04 when using USB3 port). Please read [this article](https://jolla.zendesk.com/hc/en-us/articles/360012031854).
+
+- With [v17B](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile) Sony vendor image we observed a decrease in the perceived signal strength of the 5GHz WLAN access points (investigations ongoing). Version [v16](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/) may work better in this respect. Therefore we would not recommend flashing v17B for the time being if you use WLAN networks in the 5GHz band. You can reflash the vendor image of your choice by following the instructions in [here](https://jolla.zendesk.com/hc/en-us/articles/360019346354).
+
+## Known issues specific to Xperia 10 [no changes here]
+
+- Features not yet implemented: FM radio, double-tap wakeup, support for dual-lens camera, RTC Alarms.
+- Rarely, audio playback and sensors (display rotation) may stop working. If this happens, please restart the device
+- In some cases, the acceptance of the PIN code of a SIM card may take up to 5...20 seconds
+- White balance and HDR (of the camera) do not work.
+- Transitions related to network switching 4G > 3G (call begins) and 3G > 4G (call ends) may take time on some networks. Getting the data connection of 4G might require extra actions in the worst cases. Normally, these transitions take 2-10 seconds on Xperia 10.
+
+## Known issues specific to Jolla Tablet [no changes here]
+
+- There is no progress bar during the installation phase of OS upgrades. This makes it difficult to follow if it makes progress or not. However, if there are no problems the device will restart itself in the end - please wait patiently. If you feel that you have waited enough, wait for yet another 20 minutes before you turn off the device to allow some more time for it to complete the job. Interrupting too early may break the tablet.
+- Taking screenshots is broken. Pressing the VOL keys together seems to create an image but it cannot be viewed in Gallery.
+
+## Known issues specific to Gemini PDA [no changes here]
+
+- Features not yet implemented: double-tap wakeup, RTC Alarms
+- Gemini Screenshot Button Fn + X does not work
+- Not possible to answer calls when Gemini is closed with side button
+- Some 3rd party apps have issues in Landscape mode.
+
+

--- a/Releases/Known_Issues/Kvarken/README.md
+++ b/Releases/Known_Issues/Kvarken/README.md
@@ -1,0 +1,118 @@
+---
+title: Sailfish OS 4.1.0.24 Known Issues
+permalink: Releases/Known_Issues/Kvarken/
+parent: Known Issues
+grand_parent: Releases
+layout: default
+nav_order: 400
+---
+
+This content can also be found in the [forum Release Notes](https://forum.sailfishos.org/t/release-notes-kvarken-4-1-0/5942#known-issues-generic-47).
+
+## Generic
+
+- Sailfish can connect *Bluetooth Low Energy devices*. However, Android apps cannot use peripheral devices via Bluetooth - other than for playback of the sound. Therefore smartwatches, for instance, cannot be controlled from Android apps, unfortunately.
+
+- *Signing into Dropbox* works via Google only. So, after triggering the sign-in at "Settings > Accounts > Dropbox" and the browser page dropbox.com appears, tap "Sign in with Google" (if you have a Google account).
+
+- An invalid warning and request to *uninstall all system packages* will appear if the previous OS version 4.0.1 is flashed to a device without installing the default Sailfish apps, followed by the download of the current OS version 4.1.0. This warning looks scary but it is just a warning. It should be okay to continue downloading and installing the OS update in the normal manner, i.e., you can ignore the warning. To avoid the warning, enabling the developer mode and running <code> devel-su; pkcon refresh</code> before downloading 4.1.0 may prevent the warning from appearing.
+
+- QR code reader can recognise only the 2-dimensional code that has squares in 3 corners (for positioning).
+
+- [ *developers only* ] connman-test package is broken (does not install) for devices freshly flashed with 4.1.0, because dbus-python is no longer available (requires python2). All still works if updating from 3.4.0 as in this case the old dbus-python (if it exists in rootfs) will be used.
+
+## Known issues to Android App Support 10 - Xperia 10 II, Xperia 10, and Xperia XA2
+
+- Android apps cannot use peripheral devices via Bluetooth - other than for playback of the sound. Therefore smartwatches, for instance, cannot be controlled byk Android apps.
+
+- The 'old' version of the Aptoide Store app cannot install anything anymore on Android 10. Please update the Aptoide app on your phone by downloading and installing the new version from Jolla Store - it will show a notification about Aptoide update if you have installed it from the Jolla Store in the past
+
+- Update your APKpure app to its latest version, to 3.17.19 or later.
+
+- After installing Android App Support, please restart your phone to make mobile data available for your Android apps.
+
+## Known issues specific to Xperia 10 II
+
+- Unfortunately, we cannot provide you with the Predictive text input on this phone yet. We are working on this, though. Expected in one of the next OS updates.
+
+- The Sailfish Camera app does not support the three rear cameras of this product, yet. Only one camera is supported. However, every camera is available at the middleware level for other apps to use, e.g., [Advanced Camera](https://openrepos.net/content/piggz/advanced-camera). Android "Open Camera" can use the 3 cameras, too.
+
+- White balance & light sensitivity selectors do not work on Sailfish Camera
+
+- Mobile data over 3G and 2G connections might not work. LTE/4G does work.
+
+- Top edge swipes in landscape orientation may not work so well
+
+- 5 GHz WLAN signal reception is weaker than should be
+
+- While restarting the phone for the 1st time after completing the startup wizard, Xperia 10 II tends to lose the saved WiFi network(s). This does not happen on the following restarts, though **.** Also, the first restart may harm your sign-in to your accounts. To avoid problems, please restart your phone after completing the startup wizard. Then, sign in to your WLAN and accounts. 
+
+- Wired headsets currently work as headphones during voice calls so one needs to talk into the phone's microphone during voice calls if a headset is in use
+
+- Sidetone feature is not perfectly calibrated, and sidetone volume can be a bit high in wired accessories during voice calls
+
+- There is no partition for the factory-reset image on Xperia 10 II. Therefore there is no option for the factory reset in the Settings. Instead of resetting the phone, it can be reflashed.  [This is not actually an issue but can be perceived as such.]
+
+- NOTE: Those who have installed 4.1.0 to their Xperia 10 II, used the phone with the free trial licence and installed some Android apps from Jolla Store (Aptoide, Here WeGo) already when there is no Android App Support on the phone: after buying the licence, you must *uninstall the Android apps first*. Only then can you install Android App Support.
+
+## Known issues specific to Xperia 10 [ *no changes here* ]
+
+- Features not yet implemented: FM radio, double-tap wakeup, support for dual camera, RTC Alarms.
+
+- Rarely, audio playback and sensors (display rotation) may stop working. If this happens, please restart the device
+
+- In some cases, the acceptance of the PIN code of a SIM card may take up to 5...20 seconds
+
+- White balance and HDR (of the camera) do not work.
+
+- The phone may not turn off by applying the Power key or the Top Menu. A forced power down goes like this: press both the Volume Up and Power keys down. Keep them down for 20-30 sec until the vibrator plays 3 times - now release the keys.
+
+- Transitions related to network switching 4G > 3G (call begins) and 3G > 4G (call ends) may take time on some networks. Getting the data connection via 4G back might require extra actions in the worst cases. Normally, in most networks, these transitions take few seconds on Xperia 10.
+
+## Known issues specific to Xperia XA2
+
+- Not implemented features: FM radio, double-tap wakeup, RTC Alarms
+
+- Bluetooth: there are problems in connecting to some peripheral devices
+
+- XA2 does not power up when alarm time has elapsed
+
+- Flashing Sailfish X to XA2 might still fail (so far seen to happen on Ubuntu 18.04 when using USB3 port). Please read [this article](https://jolla.zendesk.com/hc/en-us/articles/360012031854).
+
+- With [v17B](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile) Sony vendor image we observed a decrease in the perceived signal strength of the 5 GHz WLAN access points (investigations ongoing). Version [v16](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/) may work better in this respect. Therefore we would not recommend flashing v17B for the time being if you use WLAN networks in the 5 GHz band. You can reflash the vendor image of your choice by following the instructions in [here](https://jolla.zendesk.com/hc/en-us/articles/360019346354).
+
+- Some XA2 devices suffer from the loss of audio during voice calls. Reported [here](https://forum.sailfishos.org/t/3-4-0-22-xa2-phone-calls-no-audio/2446).
+
+## Known issues specific to Xperia X [ *no changes here* ]
+
+- Not implemented features: FM radio, double-tap wakeup, step counter, RTC Alarms
+
+- Issues with mobile data persist on some SIM cards. Turn the Flight mode on and off to reset the network setup. Reverting the device to Android and re-installing Sailfish X has often helped. See our [support article](https://jolla.zendesk.com/hc/en-us/articles/115004283713).
+
+- [camera] Force autofocus mode for photos, and continuous for video. After this, camera focus is still not ideal - as the camera stays out of focus when it starts until you either tap or try to take a shot - but the pictures seem to be better focused now
+
+- Bluetooth: problems with some car equipment, some audio devices and computers may appear
+
+- The loudspeaker volume level cannot be adjusted very high
+
+- Not all SD cards are recognized and mounted.
+
+## Known issues specific to Jolla Tablet [ *no changes here* ]
+
+- There is no progress bar during the installation phase of OS upgrades. This makes it difficult to follow if it makes progress or not. However, if there are no problems the device will restart itself in the end - please wait patiently. If you feel that you have waited enough, wait for yet another 20 minutes before you turn off the device to allow some more time for it to complete the job. Interrupting too early may break the tablet.
+
+- Taking screenshots is broken. Pressing the VOL keys together seems to create an image but it cannot be viewed in Gallery.
+
+## Known issues specific to Gemini PDA
+
+- **OS update to 4.1.0 seems to break the audio functions on Gemini**
+
+- Features not yet implemented: double-tap wakeup, RTC Alarms
+
+- Gemini Screenshot Button Fn + X does not work
+
+- Not possible to answer calls when Gemini is closed with side button
+
+- Some 3rd party apps have issues in Landscape mode.
+
+

--- a/Releases/Known_Issues/README.md
+++ b/Releases/Known_Issues/README.md
@@ -1,0 +1,26 @@
+---
+title: Known Issues
+permalink: Releases/Known_Issues/
+layout: default
+parent: Releases
+has_children: true
+nav_order: 100
+hide_contents: true
+---
+
+On these pages we list the major unresolved issues that are known about at time of release.
+
+## Sailfish 4
+
+The known issues for all of the Sailfish 4 releases can be found on the following pages.
+
+- [Sailfish 4.4.0.58 "Vanha Rauma"](/Releases/Known_Issues/Vanha_Rauma/)
+- [Sailfish 4.3.0.15 "Suomenlinna"](/Releases/Known_Issues/Suomenlinna/)
+- [Sailfish 4.2.0.21 "Verla"](/Releases/Known_Issues/Verla/)
+- [Sailfish 4.1.0.24 "Kvarken"](/Releases/Known_Issues/Kvarken/)
+- [Sailfish 4.0.1.48 "Koli"](/Releases/Known_Issues/Koli/)
+
+## Earlier releases
+
+For the known issues relating to versions of Sailfish OS earlier than 4.0.1, please see the release notes in [the forum](https://forum.sailfishos.org/tag/release-notes).
+

--- a/Releases/Known_Issues/Suomenlinna/README.md
+++ b/Releases/Known_Issues/Suomenlinna/README.md
@@ -1,0 +1,75 @@
+---
+title: Sailfish OS 4.3.0.15 Known Issues
+permalink: Releases/Known_Issues/Suomenlinna/
+parent: Known Issues
+grand_parent: Releases
+layout: default
+nav_order: 200
+---
+
+This content can also be found in the [forum Release Notes](https://forum.sailfishos.org/t/release-notes-suomenlinna-4-3-0/8495#known-issues-generic-48).
+
+## Generic
+
+- Bluetooth devices are not supported by Android App Support with exception of speakers.
+- *Signing into Dropbox* works via Google account linking only. So, after triggering the sign-in at "Settings > Accounts > Dropbox" and the browser page dropbox.com appears, tap "Sign in with Google" (if you have a Google account).
+- Try to avoid selecting the 0.6 camera when having the flash turned on in the video mode as this would turn the viewfinder black and hang up the camera app. Should this happen, switch the app to the still camera mode and then restart the app. *To be fixed on OS release 4.4.0.*
+- Phones updated over the air starting from OS release 3.1.0 (or earlier), may still have the packages `gittin` and `git-minimal` (which were later removed from Sailfish repositories). Now, when going to download the 4.3.0 update, Sailfish issues a warning on those two packages as if they might cause problems. This warning can be ignored, i.e., you can proceed with the update without removing the said packages. They are removed from your phone during this OS update.
+
+## Known issues to Android App Support 10 - Xperia 10 II, Xperia 10, and Xperia XA2
+
+- Sometimes, Android apps may not be able to use Internet connections via a mobile network. If there are connection problems later on (either WLAN or mobile data), stopping and starting the Android service at "Settings > Android App Support" should help. Toggling the connection off and on is another trick to try.
+
+## Known issues specific to Xperia 10 II
+
+- Top edge swipes in landscape orientation may not work very well
+- Sidetone feature is not perfectly calibrated, and sidetone volume can be a bit high in wired accessories during voice calls
+- There is no partition for the factory-reset image on Xperia 10 II. Therefore there is no option for the factory reset in the Settings. Instead of resetting the phone, it can be reflashed.
+- Mobile data does not work in 2G and 3G networks on SIM #2.
+
+## Known issues specific to Xperia 10
+
+- Features not implemented: FM radio, double-tap wakeup, support for dual camera, RTC Alarms.
+- Rarely, audio playback and sensors (display rotation) may stop working. If this happens, please restart the device
+- In some cases, the acceptance of the PIN code of a SIM card may take up to 5...20 seconds
+- The phone may not turn off by applying the Power key or the Top Menu. A forced power down goes like this: press both the Volume Up and Power keys down. Keep them down for 20-30 sec until the vibrator plays 3 times - now release the keys.
+- Transitions related to network switching 4G > 3G (call begins) and 3G > 4G (call ends) may take time on some networks. Getting the data connection via 4G back might require extra actions in the worst cases. Normally, in most networks, these transitions take a few seconds on Xperia 10.
+
+## Known issues specific to Xperia XA2
+
+- Features not implemented: FM radio, double-tap wakeup, RTC Alarms (XA2 does not power up when alarm time has elapsed )
+- Bluetooth: there are problems in connecting to some peripheral devices
+- Flashing Sailfish X to XA2 might still fail (so far seen to happen on Ubuntu 18.04 when using USB3 port). Please read [this article](https://jolla.zendesk.com/hc/en-us/articles/360012031854).
+- With [v17B](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile) Sony vendor image we observed a decrease in the perceived signal strength of the 5 GHz WLAN access points (investigations ongoing). Version [v16](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/) may work better in this respect. Therefore we would not recommend flashing v17B for the time being if you use WLAN networks in the 5 GHz band. You can reflash the vendor image of your choice by following the instructions in [here](https://jolla.zendesk.com/hc/en-us/articles/360019346354).
+- Some XA2 devices suffer from the loss of audio during voice calls. Reported [here](https://forum.sailfishos.org/t/3-4-0-22-xa2-phone-calls-no-audio/2446).
+
+## Known issues specific to Xperia X [ *no changes here* ]
+
+- Features not implemented: FM radio, double-tap wakeup, step counter, RTC Alarms
+- Issues with mobile data persist on some SIM cards. Turn the Flight mode on and off to reset the network setup. Reverting the device to Android and re-installing Sailfish X has often helped. See our [support article](https://jolla.zendesk.com/hc/en-us/articles/115004283713).
+- [camera] Force autofocus mode for photos, and continuous for video. After this, camera focus is still not ideal - as the camera stays out of focus when it starts until you either tap or you try to take a shot - but the pictures seem to be better focused now
+- Bluetooth: problems with some car equipment, some audio devices and computers may appear
+- The loudspeaker volume level cannot be adjusted very high
+- Not all SD cards are recognized and mounted.
+- There is a green stripe on the lower edge of the Camera viewfinder. This does not prevent taking pictures, though.
+
+## Known issues specific to Jolla Tablet [ *no changes here* ]
+
+- There is no progress bar during the installation phase of OS upgrades. This makes it difficult to follow if it makes progress or not. However, if there are no problems the device will restart itself in the end - please wait patiently. If you feel that you have waited enough, wait for yet another 20 minutes before you turn off the device to allow some more time for it to complete the job. Interrupting too early may break the tablet.
+- Taking screenshots is broken. Pressing the VOL keys together seems to create an image but it cannot be viewed in Gallery.
+
+## Known issues specific to Gemini PDA [ *no changes here* ]
+
+- Features not implemented: double-tap wakeup, RTC Alarms
+- Gemini Screenshot Button Fn + X does not work
+- Not possible to answer calls when Gemini is closed with a side button
+- Horizontal screen in Gemini is not supported by all 3rd party apps.
+
+## Know issues specific to Jolla C [ *no changes here* ]
+
+- If there are issues with the camera of Jolla C, do the following
+
+`/usr/bin/killall minimediaservice `
+
+and then start the camera again.
+

--- a/Releases/Known_Issues/Vanha_Rauma/README.md
+++ b/Releases/Known_Issues/Vanha_Rauma/README.md
@@ -1,0 +1,81 @@
+---
+title: Sailfish OS 4.4.0.58 Known Issues
+permalink: Releases/Known_Issues/Vanha_Rauma/
+parent: Known Issues
+grand_parent: Releases
+layout: default
+nav_order: 100
+---
+
+This content can also be found in the [forum Release Notes](https://forum.sailfishos.org/t/release-notes-vanha-rauma-4-4-0/10656#known-issues-generic-52).
+
+## Generic
+
+- Bluetooth devices are not supported by Android App Support with exception of speakers.
+- Flashing Sailfish X might fail (often caused by issues with USB ports). Please read [this article](https://jolla.zendesk.com/hc/en-us/articles/360012031854).
+- Manual Android app installation from the terminal or file managers is currently not working on the Android 4.4 version of aliendalvik on SailfishOS 4.4. To solve this, disable sandboxing for this handler by editing the file /usr/share/applications/apkd-mime-handler.desktop and adding the following to the end of the file
+
+    ```
+    [X-Sailjail]
+    Disabled
+    ```
+
+  This doesn't affect installing Android apps from the Jolla store, nor other Android stores.
+
+## Known issues specific to Android App Support 10 - Xperia 10 II, Xperia 10, and Xperia XA2
+
+- Sometimes, Android apps may not be able to use Internet connections via a mobile network. If there are connection problems later on (either WLAN or mobile data), stopping and starting the Android service at "Settings > Android App Support" should help. Toggling the connection off and on is another trick to try.
+
+## Known issues specific to Xperia 10 II
+
+- Features not implemented: Factory reset (can be done by reflashing)
+- Top edge swipes in landscape orientation may not work very well
+- The sidetone feature is not perfectly calibrated, and sidetone volume can be a bit high in wired accessories during voice calls
+- Mobile data does not work in 2G and 3G networks on SIM #2.
+
+## Known issues specific to Xperia 10
+
+- Features not implemented: FM radio, double-tap wakeup, support for dual camera, RTC Alarms.
+- Rarely, audio playback and sensors (display rotation) may stop working. If this happens, please restart the device
+- In some cases, the acceptance of the PIN code of a SIM card may take up to 5...20 seconds
+- The phone may not turn off by applying the Power key or the Top Menu. A forced power down goes like this: press both the Volume Up and Power keys down. Keep them down for 20-30 sec until the vibrator plays 3 times - now release the keys
+- Transitions related to network switching 4G > 3G (call begins) and 3G > 4G (call ends) may take time on some networks. Getting the data connection via 4G back might require extra actions in the worst cases. Normally, in most networks, these transitions take a few seconds on Xperia 10.
+
+## Known issues specific to Xperia XA2
+
+- Features not implemented: FM radio, double-tap wakeup, RTC Alarms (XA2 does not power up when alarm time has elapsed )
+- Bluetooth: there are problems in connecting to some peripheral devices
+- With [v17B](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile) Sony vendor image we observed a decrease in the perceived signal strength of the 5 GHz WLAN access points (investigations ongoing). Version [v16](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/) may work better in this respect. Therefore we would not recommend flashing v17B for the time being if you use WLAN networks in the 5 GHz band. You can reflash the vendor image of your choice by following the instructions in [here](https://jolla.zendesk.com/hc/en-us/articles/360019346354).
+- Some XA2 devices suffer from the loss of audio during voice calls. Reported [here](https://forum.sailfishos.org/t/3-4-0-22-xa2-phone-calls-no-audio/2446).
+
+## Known issues specific to Xperia X [ *no changes here* ]
+
+- Features not implemented: FM radio, double-tap wakeup, step counter, RTC Alarms
+- Issues with mobile data persist on some SIM cards. Turn the Flight mode on and off to reset the network setup. Reverting the device to Android and re-installing Sailfish X has often helped. See our [support article](https://jolla.zendesk.com/hc/en-us/articles/115004283713).
+- [camera] Force autofocus mode for photos, and continuous for video. After this, camera focus is still not ideal - as the camera stays out of focus when it starts until you either tap or you try to take a shot - but the pictures seem to be better focused now
+- Bluetooth: problems with some car equipment, some audio devices and computers may appear
+- The loudspeaker volume level cannot be adjusted very high
+- Not all SD cards are recognized and mounted.
+- There is a green stripe on the lower edge of the Camera viewfinder. This does not prevent taking pictures, though.
+
+## Known issues specific to Jolla Tablet [ *no changes here* ]
+
+- There is no progress bar during the installation phase of OS upgrades. This makes it difficult to follow if it makes progress or not. However, if there are no problems the device will restart itself in the end - please wait patiently. If you feel that you have waited enough, wait for yet another 20 minutes before you turn off the device to allow some more time for it to complete the job. Interrupting too early may break the tablet.
+- Taking screenshots is broken. Pressing the VOL keys together seems to create an image but it cannot be viewed in Gallery.
+
+## Known issues specific to Gemini PDA [ *no changes here* ]
+
+- Features not implemented: double-tap wakeup, RTC Alarms
+- Gemini Screenshot Button Fn + X does not work
+- Not possible to answer calls when Gemini is closed with a side button
+- Horizontal screen in Gemini is not supported by all 3rd party apps.
+
+## Know issues specific to Jolla C [ *no changes here* ]
+
+- If there are issues with the camera of Jolla C, do the following
+
+  `/usr/bin/killall minimediaservice`
+
+  and then start the camera again.
+
+

--- a/Releases/Known_Issues/Verla/README.md
+++ b/Releases/Known_Issues/Verla/README.md
@@ -1,0 +1,80 @@
+---
+title: Sailfish OS 4.2.0.21 Known Issues
+permalink: Releases/Known_Issues/Verla/
+parent: Known Issues
+grand_parent: Releases
+layout: default
+nav_order: 300
+---
+
+This content can also be found in the [forum Release Notes](https://forum.sailfishos.org/t/release-notes-verla-4-2-0/7092#known-issues-generic-46).
+
+## Generic
+
+- Do not install WhatsApp from the Aptoide store now. There seems to be a fake app. Use alternative app stores, e.g. APK Pure.
+- Sailfish can connect *Bluetooth Low Energy devices*. However, Android apps cannot use peripheral devices via Bluetooth - other than for playback of the sound. Therefore smartwatches, for instance, cannot be controlled from Android apps, unfortunately.
+- *Signing in to Dropbox* works via Google account linking only. So, after triggering the sign-in at "Settings > Accounts > Dropbox" and the browser page dropbox.com appears, tap "Sign in with Google" (if you have a Google account).
+- The predictive text bar may get stuck, especially by dragging the keyboard down to close then reopening and the dragging down starting from one of the prediction items. In such a case, drag the keyboard sideways (switch to another keyboard and back) to revive the prediction bar.
+- On some devices, the Camera app is sluggish to open.
+- Issues related to IPv4 and IPv6 protocols.
+
+## Known issues to Android App Support 10 - Xperia 10 II, Xperia 10, and Xperia XA2
+
+- Sometimes, Android apps may not be able to use Internet connections via a mobile network. This happens typically right after installing Android App Support. In such a case, restart your phone *[will be fixed to OS update 4.3.0]*. If there are connection problems later on (either WLAN or mobile data), stopping and starting the Android service at "Settings > Android App Support" should help.
+
+## Known issues specific to Xperia 10 II
+
+- Top edge swipes in landscape orientation may not work very well
+- Sidetone feature is not perfectly calibrated, and sidetone volume can be a bit high in wired accessories during voice calls
+- There is no partition for the factory-reset image on Xperia 10 II. Therefore there is no option for the factory reset in the Settings. Instead of resetting the phone, it can be reflashed.
+- Mobile data does not work in 2G and 3G networks on SIM #2.
+- Predictive text input may not show relevant words in some languages. To be fixed on OS release 4.3.0.
+
+## Known issues specific to Xperia 10
+
+- Features not implemented: FM radio, double-tap wakeup, support for dual camera, RTC Alarms.
+- Rarely, audio playback and sensors (display rotation) may stop working. If this happens, please restart the device
+- In some cases, the acceptance of the PIN code of a SIM card may take up to 5...20 seconds
+- The phone may not turn off by applying the Power key or the Top Menu. A forced power down goes like this: press both the Volume Up and Power keys down. Keep them down for 20-30 sec until the vibrator plays 3 times - now release the keys.
+- Transitions related to network switching 4G > 3G (call begins) and 3G > 4G (call ends) may take time on some networks. Getting the data connection via 4G back might require extra actions in the worst cases. Normally, in most networks, these transitions take few seconds on Xperia 10.
+
+## Known issues specific to Xperia XA2
+
+- Features not implemented: FM radio, double-tap wakeup, RTC Alarms (XA2 does not power up when alarm time has elapsed )
+
+- Bluetooth: there are problems in connecting to some peripheral devices
+
+- Flashing Sailfish X to XA2 might still fail (so far seen to happen on Ubuntu 18.04 when using USB3 port). Please read [this article](https://jolla.zendesk.com/hc/en-us/articles/360012031854).
+- With [v17B](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile) Sony vendor image we observed a decrease in the perceived signal strength of the 5 GHz WLAN access points (investigations ongoing). Version [v16](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/) may work better in this respect. Therefore we would not recommend flashing v17B for the time being if you use WLAN networks in the 5 GHz band. You can reflash the vendor image of your choice by following the instructions in [here](https://jolla.zendesk.com/hc/en-us/articles/360019346354).
+- Some XA2 devices suffer from the loss of audio during voice calls. Reported [here](https://forum.sailfishos.org/t/3-4-0-22-xa2-phone-calls-no-audio/2446).
+
+## Known issues specific to Xperia X [ *no changes here* ]
+
+- Features not implemented: FM radio, double-tap wakeup, step counter, RTC Alarms
+- Issues with mobile data persist on some SIM cards. Turn the Flight mode on and off to reset the network setup. Reverting the device to Android and re-installing Sailfish X has often helped. See our [support article](https://jolla.zendesk.com/hc/en-us/articles/115004283713).
+- [camera] Force autofocus mode for photos, and continuous for video. After this, camera focus is still not ideal - as the camera stays out of focus when it starts until you either tap or try to take a shot - but the pictures seem to be better focused now
+- Bluetooth: problems with some car equipment, some audio devices and computers may appear
+- The loudspeaker volume level cannot be adjusted very high
+- Not all SD cards are recognized and mounted.
+- There is a green stripe on the lower edge of the Camera viewfinder. This does not prevent taking pictures, though.
+
+## Known issues specific to Jolla Tablet [ *no changes here* ]
+
+- There is no progress bar during the installation phase of OS upgrades. This makes it difficult to follow if it makes progress or not. However, if there are no problems the device will restart itself in the end - please wait patiently. If you feel that you have waited enough, wait for yet another 20 minutes before you turn off the device to allow some more time for it to complete the job. Interrupting too early may break the tablet.
+- Taking screenshots is broken. Pressing the VOL keys together seems to create an image but it cannot be viewed in Gallery.
+
+## Known issues specific to Gemini PDA
+
+- Features not implemented: double-tap wakeup, RTC Alarms
+- Gemini Screenshot Button Fn + X does not work
+- Not possible to answer calls when Gemini is closed with a side button
+- Horizontal screen in Gemini is not supported by all 3rd party apps.
+
+## Know issues specific to Jolla C
+
+- If there are issues with the camera of Jolla C, do the following
+
+     `/usr/bin/killall minimediaservice `
+
+     and then start the camera again.
+

--- a/Releases/README.md
+++ b/Releases/README.md
@@ -2,7 +2,7 @@
 title: Releases
 permalink: Releases/
 layout: default
-nav_exclude: true
+has_children: true
 ---
 
 ## Sailfish 4 - Finnish Unesco world heritage sites


### PR DESCRIPTION
Introduces a Known Issues subsection to the Releases section, for
documenting the known issues in each release.

Pre-populates the subsection with the Known Issues taken from the
Release Notes of the last five releases (all the Sailfish 4 releases up
to this point).