### PR TITLE
Add warning regarding user added adaptation-common

### DIFF
--- a/Reference/Sailfish_OS_Cheat_Sheet/README.md
+++ b/Reference/Sailfish_OS_Cheat_Sheet/README.md
@@ -404,8 +404,22 @@ ssu lr                  # list
 ssu updaterepos
 pkcon refresh
 pkcon update
-```    
-    
+```
+
+Never override global repositories such as *adaptation-common* as that will mess up your device when upgrading it. Before upgrade make sure *Enabled repositories (global)* are not listed in *Enabled repositories (user)* as follows:
+
+```nosh
+devel-su ssu lr
+```
+
+If you have *Enabled repositories (global)* listed in the *Enabled repositories (user)*, remove each of them as follows (e.g. *adaptation-common*):
+
+```nosh
+devel-su ssu rr adaptation-common
+devel-su ssu up
+devel-su pkcon refresh
+```
+
 ## Package Handling
 
 Privileged rights required


### PR DESCRIPTION
Add warning regarding user added adaptation-common. Users should
never add adaptation-common themselves rather it should be the one
coming from the global ssu settings.

See JB#57866