### PR TITLE
 Simplify Opensource documentation

### DIFF
--- a/Develop/Open_Source/README.md
+++ b/Develop/Open_Source/README.md
@@ -9,46 +9,19 @@ nav_order: 600
 
 As described in the [architecture documentation](/Reference/Architecture) Sailfish OS consists of a variety of components, some of which are proprietary and closed source (such as some hardware-specific kernel modules, or other software licensed under commercial terms), and most of which are open source.
 
-The various open source components have different licenses depending on the licensing decision by the upstream maintainers. Sailfish OS respects and abides by these license requirements. Some of these licenses are highly permissive open source licenses, while others entail specific legal requirements which are described in further detail below.
+The various open source components have different licenses depending on the licensing decision by the upstream maintainers. Sailfish OS respects these license requirements, which can also be [read from the device](/Support/Help_Articles/Tips_and_Tricks/#checking-open-source-licenses). Some of these licenses are highly permissive open source licenses, while others entail specific legal requirements which are described in further detail below.
 
-## Understanding Open Source and Free Software
+Most common licenses used in the Sailfish OS are:
+ * [LGPLv2+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
+ * [BSD](https://fedoraproject.org/wiki/Licensing:BSD#3ClauseBSD)
+ * [GPLv2+](http://www.gnu.org/licenses/old-licenses/gpl-2.0.html)
+ * [MIT](https://fedoraproject.org/wiki/Licensing:MIT)
 
-Let's look at two of the key ideas that you'll come across in this area: Free Software and Open Source Software.
+In Sailfish OS we follow [Fedora's shortnames](https://fedoraproject.org/wiki/Licensing:Main#Good_Licenses) for the license names.
 
-### Free Software
-
-A long, long time ago, way back in the 20th century, a chap called Richard Stallman worked in a lab which had a printer. He'd modified the software on the printer to tell users when it needed attention. He became annoyed when the lab got a newer model of printer and the manufacturers refused to share the code to allow him to make a similar modification. He thought this was selfish.
-
-This lead Richard to develop a philosophy in which users should have the freedom to see and change the software that operates the machines they interact with. He began to work on what became known as 'Free' software.
-
-Of course the word free has two meanings but the more important one in this context is not financial cost but personal freedom. This explanation is often summarised as:
-
-"Free as in freedom, not as in beer".
-
-The next step was to actually write some Free Software, in fact a complete operating system - and so the GNU OS was born.
-
-Just as important as the software was a way to **prevent** anyone from restricting users. This lead him to investigate the legal framework around copyrights and licenses that generally governing its use and come up with the idea of 'copyleft' (a play on the word copyright) and the GNU General Public License - the GPL.
-
-#### GPL Licensing
-
-The Gnu General Public License guarantees end users (individuals, organizations, companies) the freedoms to run, study, share (copy), and modify software carrying the license.
-
-It uses what is known as copyleft to ensure that these freedoms are retained when the software is distributed.
+There are a number of licenses which permit and encourage the sharing of source code associated with software and you'll find a mix of these licenses in the source that makes up Sailfish OS. Some of these licenses are highly permissive, while others more strictly enforce the "copyleft" requirements, such as GPL.
 
 The essence of the GPL is that you **can** share and modify the software but that you **must** share the source of any modifications you've made if you redistribute the software - ie it's about playing fair.
 
 You can read more about the [GPL here](https://en.wikipedia.org/wiki/GNU_General_Public_License).
 
-### Open Source
-
-There are a number of licenses which permit and encourage the sharing of source code associated with software and you'll find a mix of these licenses in the source that makes up Sailfish OS. Some of these licenses are highly permissive, while others more strictly enforce the "copyleft" requirements described above.
-
-To many people there is a clear distinction between "Free Software" and "Open Source Software"; the former is, to some degree, a political position whereas the latter is an economical or collaborative solution which happens to be leveraged by the Free Software movement.
-
-Aside from any ideological position, if ten companies each put one man-year's worth of development effort into a software component then they'll each benefit from a total of ten man-years worth of results - that's a fairly good economic proposition!
-
-Ultimately Open Source is about sharing and collaborating - not about why you choose to share and collaborate.
-
-## Legal Situation
-
-The best advice is to get professional advice from a member of the legal profession who is familiar with Open Source licensing in your country. For a complete list of the license information entailed by Sailfish OS, please contact the legal team of Jolla Oy.

--- a/Support/Help_Articles/Tips_and_Tricks/README.md
+++ b/Support/Help_Articles/Tips_and_Tricks/README.md
@@ -363,4 +363,13 @@ Type the following command to delete the filesystem indexer database:
 tracker3 reset -s
 ```
 
+# Checking Open Source Licenses
 
+Easiest way to check licenses is to go to **Settings > About product** and scroll a bit down and click "see information about packages" which takes you to the list of packages with licenses and shows you all the open source licenses.
+
+If you have AppSupport installed you can check open source licenses related to AppSupport at **Settings > Android<sup>TM</sup> App Support > Show licences**
+
+You can also use following command in terminal in case you have developer mode installed:
+```
+rpm -qa --queryformat '%{license}\t%{name}-%{version}-%{release}\n'
+```


### PR DESCRIPTION
This is not tested yet, just pushed the current draft foward.

- Simplify the open source documentation.
- Add first HowTo page
- Add HowTo about checking licenses from a device. JB#58515

Signed-off-by: Marko Saukko <marko.saukko@jolla.com>