### PR TITLE
Remove WebKit reference from email rendering

### DIFF
--- a/Reference/Core_Areas_and_APIs/Apps_and_MW/Email/README.md
+++ b/Reference/Core_Areas_and_APIs/Apps_and_MW/Email/README.md
@@ -13,7 +13,7 @@ Sailfish OS supports a number of email communication protocols and services. The
   - SMTP, POP3 and IMAP access
   - Microsoft Exchange ActiveSync access
   - Scheduling of email synchronization through the Buteo synchronization framework
-  - Rendering of HTML emails through WebKit
+  - All emails, text/plain and text/html, rendered with [Sailfish WebView](https://github.com/sailfishos/sailfish-components-webview/)
 
 Email features are primarily implemented by the following packages:
 


### PR DESCRIPTION
Nowadays all (text/plain and text/html) emails are rendered with Sailfish WebView and QtWebKit has been deprecated.

See https://forum.sailfishos.org/t/deprecation-notice-silicawebview-qtwebkit