### PR TITLE
Update web-link to stale content at TJC

### DIFF
--- a/Support/Help_Articles/Flashing_Troubleshooting/README.md
+++ b/Support/Help_Articles/Flashing_Troubleshooting/README.md
@@ -92,7 +92,7 @@ Also, send the output from the terminal window showing how the execution of the 
 ## Can the Sailfish community help
 
 Our community has many talented persons, even experts. One of them has composed the following instructions for those struggling with Sailfish installation. 
-The article (read-only) is beyond this **[link](https://together.jolla.com/question/222126/)**.
+The article (read-only) is beyond this **[link](https://gitlab.com/Olf0/sailfishX#guide-installing-sailfishx-on-xperias)**.
 We/Jolla have not tested the tricks and methods of that article. They may or may not help. Following those instructions requires a fair amount of skills with Linux commands and computer systems, so we do not recommend them for beginners. Use them with care and at your own risk.
 
 You can also search help or send questions to the **[Forum](https://forum.sailfishos.org/)**.


### PR DESCRIPTION
While I feel honored by the fact that @jpwalden mentions my "Guide for installing Sailfish X on Sony Xperias" in his [PR 141 "Creating Flashing Troubleshooting article"](https://github.com/sailfishos/docs.sailfishos.org/pull/141/files#diff-148bb7402f0f46f63163e1c3a572b9bebbd811e9d65dcf58e175b79e03d27d24R95), it links to [an outdated version of this guide (the one at TJC)](https://together.jolla.com/question/222126/), because TJC was set to "read only" at the end of 2020, hence the version there cannot be updated ever since.  
Thus the canonical URL for this guide is [https://gitlab.com/Olf0/sailfishX#guide-installing-sailfishx-on-xperias](https://gitlab.com/Olf0/sailfishX#guide-installing-sailfishx-on-xperias), where it is still maintained.

This PR solely swaps the stale URL with the current one.