### PR TITLE
Restructure and add information about I18n

### DIFF
--- a/Reference/I18n/Application_Configuration/README.md
+++ b/Reference/I18n/Application_Configuration/README.md
@@ -1,0 +1,86 @@
+---
+title: Application Configuration
+permalink: Reference/I18n/Application_Configuration/
+parent: I18n
+layout: default
+nav_order: 300
+---
+
+This page explains how to configure your application for internationalisation on Sailfish OS. These details are also covered in the [Libsailfishapp](https://sailfishos.org/develop/docs/libsailfishapp/#using-i18n-support-in-your-project) documentation.
+
+As an application developer you have more freedom for how you format and make use of the Qt internationalisation capabilities compared to Platform development. Nevertheless, in the longer term you may find it convenient to follow the [I18n Conventions](/Reference/I18n/I18n_Conventions) for your app.
+
+You may also find it useful to reference the Qt documentation on [Qt Quick internationalisation](https://doc.qt.io/qt-5/qtquick-internationalization.html) and [Qt Linguist](https://doc.qt.io/qt-5/linguist-programmers.html).
+
+In the examples below we assume your app is called **harbour-myapp**; you'll need to adjust the statements to use the correct name for your app.
+
+## The project .yaml and .spec files
+
+If you use either the Sailfish IDE, or `sfdk init` to create a new application, the translation functionality will be configured automatically. This is the same whether you're developing a QtQuick2 or a QML-only app. For most app development, there should therefore be no need to make changes to the `.yaml` or `.spec` files to support translations.
+
+Nevertheless we briefly explain which parts of the file are relevant, in case a more elaborate configuration is needed.
+
+The default `sailfishapp` dependency added to the `.yaml` file, which will be used to generate the `.spec` file for your project, should be sufficient to handle the translations for your app:
+
+```
+PkgConfigBR:
+  - sailfishapp >= 1.0.2
+```
+
+The generated ".qm" translation files (Engineering English and any other languages you add) are by default installed with the normal package under the `/usr/share/harbour-myapp/translations` directory, and will be automatically picked up by the application when it runs.
+
+The following snippet, automatically added to the `.yaml` file, is used for this:
+
+```
+Files:
+  - '%{_datadir}/%{name}'
+```
+
+This section of `.yaml` is converted into the following snippet in the `.spec` file:
+
+```
+%files
+%{_datadir}/%{name}
+```
+
+## The project pro file
+
+The automatically generated qmake pro file will also be set up to support translations. However, there are reasons why you might want to make changes to this file, for example when adding support for additional languages.
+
+The most important lines related to translation can be found at the end of the generated pro file.
+
+```qmake
+# to disable building translations every time, comment out the
+# following CONFIG line
+CONFIG += sailfishapp_i18n
+
+# German translation is enabled as an example. If you aren't
+# planning to localize your app, remember to comment out the
+# following TRANSLATIONS line. And also do not forget to
+# modify the localized app name in the the .desktop file.
+TRANSLATIONS += translations/harbour-myapp-de.ts
+```
+
+The comments included in the file should be self-explanatory, but we will also cover them here for completeness.
+
+This default configuration assumes you will be using non-ID-based translations. For ID-based translations, you should update the `CONFIG` line to the following:
+```
+CONFIG += sailfishapp_i18n \
+          sailfishapp_i18n_idbased
+```
+
+To support additional languages, add them to the `TRANSLATIONS` list.
+
+```
+TRANSLATIONS += translations/harbour-myapp-de.ts \
+                translations/harbour-myapp-en.ts \
+                translations/harbour-myapp-zh_CN.ts
+```
+
+After making changes to the pro file, you'll need to run `qmake` in order for the changes to be picked up, before performing another build.
+
+## Disabling translation generation
+
+Simply comment out the `CONFIG` lines described in the previous section in order to disable translation generation. This may be useful to speed up the build process during development.
+
+

--- a/Reference/I18n/I18n_Conventions/README.md
+++ b/Reference/I18n/I18n_Conventions/README.md
@@ -1,0 +1,110 @@
+---
+title: I18n Conventions
+permalink: Reference/I18n/I18n_Conventions/
+parent: I18n
+layout: default
+nav_order: 200
+---
+
+This page explains general conventions which should be followed for internationalisation of Sailfish OS Platform projects, and which also represent helpful guidelines for Sailfish OS applications too.
+
+## Internationalised Text
+
+All human-readable strings in an application or service need to be embedded in such a way that they can be translated. In Sailfish OS applications, the internationalisation capabilities of Qt are leveraged to provide run-time translation of strings. This means that instead of embedding the human-readable string directly in source code, instead the code contains the identifier of a string, and at run-time the appropriate (UTF-8) string (for that identifier, given the current locale) is displayed.
+
+In C++ the `qtTrId()` function should be used. The `lupdate` tool will scan C++ code for uses of this function, and generate the appropriate translation output files for the application or service. The `qtTrId()` function should be used as follows:
+
+```qml
+//: This is the context string, which describes to translators in which context the string will be displayed
+//% "This is the engineering-english translation, i.e., the string the developer would expect to see in an English localisation"
+const QString exampleString = qtTrId("example_internationalised_string_id");
+```
+
+In QML the `qsTrId()` function should be used. The semantics are identical to the `qtTrId()` function. An example of its use follows:
+
+```qml
+Button {
+    //: This text will be displayed in a button, which when clicked will quit the application.
+    //% "Quit"
+    text: qsTrId("example_application-bt-quit")
+    onClicked: Qt.quit()
+}
+```
+
+Lines starting with `//:` indicate context, provided to the translator to help them in translating. These are always worth adding and are helpful to the translators, but not compulsory.
+
+The following line starting with `//%` indicates the engineering English, a fallback translation if proper translation is missing.
+Last creates the actual translation. The ID is formed as `<component>-<placement>-<descriptive text>`.
+
+When developing platform components, `qtTrId()` and `qsTrId()` *must* be used. If you're developing your own application you also have the option to use `tr()` and `qsTr()` instead. The latter offers a simpler approach, while the former offers greater flexibility in some situations.
+
+For details about how to set up your projects for use with translations, and for the differences between platform and application development localisation, see the [Platform](/Reference/I18n/Platform_Configuration) and [Application](/Reference/I18n/Application_Configuration) pages respectively.
+
+## Platform application style requirements
+
+IDs can be reused if it is clear the string has exactly same meaning in the locations used. Keep engineering English included in all occasions. 
+
+Current placement codes are as follows.
+
+| Code | Summary                 | Description
+| ---- | ----------------------- | --------------------------------------------------------|
+|  ap  |  application name       | Application name, e.g. Media player                     |
+|  he  |  header                 | Header in view, e.g. Media player: Music                |
+|  bt  |  button                 | Application area buttons                                |
+|  no  |  notification           | Notification                                            |
+|  bu  |  button                 | Notification area buttons                               |
+|  me  |  menu item              | Pull-down or push-up menu item, e.g. Edit contact       |
+|  li  |  list item              | Item without data to be displayed, e.g. (unnamed)       |
+|  la  |  label                  | Context menu label, e.g. First name                     |
+|  va  |  value                  | Context menu value, e.g. In Settings: Language: Finnish |
+|  ph  |  textfield placeholders |
+
+In practice the usage has not always been consistent, and should be considered as guidelines.
+
+## Line breaks in translations
+
+It is recommended not to use line breaks in user interface translations as typically translations are 1-2 sentences long and line break can cause text being badly aligned. Exceptions like several paragraphs of text: Use \<\p> or \<br\> for line break.
+
+## Colons
+
+Colons are not carried in translations. If colons are needed, those are added at the code level. Note that for "key: value" type constructs (e.g. combo boxes, informatin labels) colons should generally not be used. The platform style is to instead use colour/emphasis to differentiate the two elements.
+
+See the Combo box page of the Sailfish Silica Component Gallery for good usage of combo boxes without colons.
+
+An example of the case for labels can be seen on the CertificateInfo.qml page (Settings app > System > Certificates > TLS Certificates > Certificate). Here the *key* portion uses `secondaryHighlightColor` while the *value* portion uses `highlightColor`.
+
+## Application names
+
+When creating a `.desktop` file for an application, localised names can be supported as follows:
+
+```
+Name=Appname
+X-Amber-Translation-Id-Name=appname-ap-name
+X-Amber-Translation-Catalog=appname
+```
+
+The translation for the ID `appname-ap-name` should be declared in the application code, like this:
+
+```
+//% "Appname"
+QCoreApplication::setApplicationName(qtTrId("appname-ap-name"));
+```
+
+## Other things to localise
+
+Localisation does not stop at having the application translated. Many other details also depend
+on the locale, and should be taken into account, such as:
+
+ * date and time formatting, 12/24h
+ * number formatting
+ * first day of week
+ * currency formatting
+ * translation can contain plural/singular. Use %n (https://doc.qt.io/qt-5/i18n-source-translation.html#handling-plurals)
+ * translation can contain changing values. Use %1, %2 of QString
+ * collation (sorting strings)
+ * city/country names
+ * different calendar systems
+ * word and sentence boundaries
+ * upper and lower casing strings
+ * bidirectional text has quite a few details (not part of first release content)
+

--- a/Reference/I18n/Platform_Configuration/README.md
+++ b/Reference/I18n/Platform_Configuration/README.md
@@ -1,0 +1,187 @@
+---
+title: Platform Configuration
+permalink: Reference/I18n/Platform_Configuration/
+parent: I18n
+layout: default
+nav_order: 200
+---
+
+This page explains how to configure your Platform project for internationalisation.
+
+## The project .spec file
+
+The tools `lupdate` and `lrelease` are included in `qt5-qttools-linguist`, so add that as a `BuildRequires` requirement. The ".qm" file (Engineering English) gets installed with the normal package (`%files`), the ".ts" file (translation source) gets installed with the `-ts-devel` package.
+
+```
+BuildRequires: qt5-qttools-linguist
+
+(...)
+
+%files
+%{_datadir}/translations/*.qm
+
+(...)
+
+%package ts-devel
+Summary: Translation source for %{name}
+License: XXX
+
+%description ts-devel
+%{summary}.
+
+%files ts-devel
+%{_datadir}/translations/source/*.ts
+```
+
+## The project pro file
+
+The simplest way to add translations to your project is to add the following to your qmake project (.pro) file, so that it will trigger `lupdate` to generate the translation files:
+
+```qmake
+# Translation Source
+TS_FILE = $$OUT_PWD/$$TARGET.ts
+
+# Engineering English Translation
+EE_QM = $$OUT_PWD/$$TARGET_eng_en.qm
+
+ts.commands += lupdate $$PWD -ts $$TS_FILE
+ts.CONFIG += no_check_exist
+ts.output = $$TS_FILE
+ts.input = .
+
+ts_install.files = $$TS_FILE
+ts_install.path = /usr/share/translations/source
+ts_install.CONFIG += no_check_exist
+
+engineering_english.commands += lrelease -idbased $$TS_FILE -qm $$EE_QM
+engineering_english.CONFIG += no_check_exist
+engineering_english.depends = ts
+engineering_english.input = $$TS_FILE
+engineering_english.output = $$EE_QM
+
+engineering_english_install.path = /usr/share/translations
+engineering_english_install.files = $$EE_QM
+engineering_english_install.CONFIG += no_check_exist
+
+QMAKE_EXTRA_TARGETS += ts engineering_english
+PRE_TARGETDEPS += ts engineering_english
+INSTALLS += ts_install engineering_english_install
+```
+
+Alternatively, if you prefer to use subdirs, you should add `SUBDIRS += translations` to the top-level project file, then create `translations/translations.pro` containing the following:
+
+```qmake
+TEMPLATE = aux
+
+# Set name of translation catalog here
+TRANSLATION_CATALOG = XXX
+
+# Translation Source
+TS_FILE = $$OUT_PWD/$${TRANSLATION_CATALOG}.ts
+
+# Engineering English Translation
+EE_QM = $$OUT_PWD/$${TRANSLATION_CATALOG}_eng_en.qm
+
+ts.commands += lupdate $$PWD/.. -ts $$TS_FILE
+ts.CONFIG += no_check_exist no_link
+ts.output = $$TS_FILE
+ts.input = ..
+
+ts_install.files = $$TS_FILE
+ts_install.path = /usr/share/translations/source
+ts_install.CONFIG += no_check_exist
+
+# XXX should add -markuntranslated "-" when proper translations are in place
+engineering_english.commands += lrelease -idbased $$TS_FILE -qm $$EE_QM
+engineering_english.CONFIG += no_check_exist no_link
+engineering_english.depends = ts
+engineering_english.input = $$TS_FILE
+engineering_english.output = $$EE_QM
+
+engineering_english_install.path = /usr/share/translations
+engineering_english_install.files = $$EE_QM
+engineering_english_install.CONFIG += no_check_exist
+
+QMAKE_EXTRA_TARGETS += ts engineering_english
+PRE_TARGETDEPS += ts engineering_english
+INSTALLS += ts_install engineering_english_install
+```
+
+## Translation loading and harvesting
+
+The `lupdate` utility is used to gather IDs to be translated from code. It produces an XML .ts file that
+is then used to create the translations. The `lrelease` tool compiles a translated .ts file into binary
+.qm file, which is finally loaded by the application.
+
+Sailfish platform app translations should be deployed to `/usr/share/translations/`.
+The Engineering English translation file should follow the format `<component>_eng_en.qm` and the actual
+translations have a locale suffix as in `<component>-fi_FI.qm`. By loading first the Engineering English
+translations and then the real ones based on locale, it's guaranteed that no IDs are shown in the user
+interface. Loading happens with QTranslator on the C++ side:
+
+```
+#define I18N_APP "appname"
+#define I18N_DIR "/usr/share/translations"
+    
+QTranslator translator_eng_en;
+translator_eng_en.load(I18N_APP "_eng_en", I18N_DIR);
+app.installTranslator(&translator_eng_en);
+    
+QTranslator translator;
+translator.load(QLocale(), I18N_APP, "-", I18N_DIR);
+app.installTranslator(&translator);
+```
+
+The generated .ts file should be installed into `/usr/share/translations/source/<component>.ts` and
+packaged into `<component>-ts-devel.rpm`. It can then be automatically used for translation services
+which eventually produce the locale based translations files. The actual translations are not put 
+into the source code repository.
+
+For pure QML plugins, the localisation support is unfortunately not so easy. Translation files need
+to be loaded before any text property gets set which complicates things. A solution is to have the
+C++ side of the plugin take care of initialisation:
+
+```
+...
+#include <QTranslator>
+
+class AppTranslator: public QTranslator
+{
+    Q_OBJECT
+public:
+    AppTranslator(QObject *parent)
+        : QTranslator(parent)
+    {
+        qApp->installTranslator(this);
+    }
+
+    ~AppTranslator() override
+    {
+        qApp->removeTranslator(this);
+    }
+};
+
+class SailfishModulenamePlugin : public QQmlExtensionPlugin
+{
+    ...
+public:
+    void initializeEngine(QQmlEngine *engine, const char *uri)
+    {
+        if (QLatin1String(uri) != QLatin1String("Sailfish.Modulename")) {
+            return;
+        }
+        ...
+
+        AppTranslator *engineeringEnglish = new AppTranslator(engine);
+        AppTranslator *translator = new AppTranslator(engine);
+        AppTranslator *modulenameTranslator = new AppTranslator(engine);
+        engineeringEnglish->load("sailfish_components_modulename_eng_en", "/usr/share/translations");
+        translator->load(QLocale(), "sailfish_components_modulename", "-", "/usr/share/translations");
+        modulenameTranslator->load(QLocale(), "modulename", "-", "/usr/share/translations");
+    }
+    ...
+};
+```
+
+
+

--- a/Reference/I18n/README.md
+++ b/Reference/I18n/README.md
@@ -1,72 +1,24 @@
 ---
 title: I18n
 permalink: Reference/I18n/
+has_children: true
 layout: default
 nav_order: 400
 ---
 
+The following sections explain how to configure Sailfish OS Platform and Application projects for internationalisation (I18n).
+
 ## Internationalisation
 
-All of the core components of Sailfish OS are fully internationalised, including the Silica UI components as well as core Sailfish OS services and applications. This means that the content of each application and service can be localised to support some specific combination of language, script, input method, and directionality, and that the user experience of the core Sailfish OS services and applications are not hardcoded to only support some specific region's requirements.
+All of the core components of Sailfish OS are fully internationalised, including the Silica User Interface components as well as core Sailfish OS services and applications. This means that the content of each application and service can be localised to support some specific combination of language, script, input method, and directionality, and that the user experience of the core Sailfish OS services and applications are not hardcoded to only support some specific region's requirements.
 
 When writing new applications or services to contribute to Sailfish OS, it is important to ensure that the contribution is internationalised, so that all users of Sailfish OS can eventually benefit from it.
 
-### Internationalised Text
+As far as possible Sailfish OS makes use of the existing Qt internationalisation capabilities. You may therefore find it useful to refer to the Qt documentation on [Qt Quick internationalisation](https://doc.qt.io/qt-5/qtquick-internationalization.html) and [Qt Linguist](https://doc.qt.io/qt-5/linguist-programmers.html).
 
-All human-readable strings in an application or service need to be embedded in such a way that they can be translated. In Sailfish OS applications, the internationalisation capabilities of Qt are leveraged to provide run-time translation of strings. This means that instead of embedding the human-readable string directly in source code, instead the code contains the identifier of a string, and at run-time the appropriate (UTF-8) string (for that identifier, given the current locale) is displayed.
+However, we also have our own conventions and technical requirements which are detailed on these pages. Here you can read more information about the [general conventions](/Reference/I18n/I18n_Conventions) that all Sailfish OS projects need to consider. We also have specific details about the canonical way to configure Qt-based [Platform projects](/Reference/I18n/Platform_Configuration) and [Sailfish applications](/Reference/I18n/Application_Configuration) for internationalisation.
 
-In C++ the qtTrId() function should be used. The `lupdate` tool will scan C++ code for uses of this function, and generate the appropriate translation output files for the application or service. The qtTrId() function should be used as follows:
-```qml
-//: This is the context string, which describes to translators in which context the string will be displayed
-//% "This is the engineering-english translation, i.e., the string the developer would expect to see in an English localisation"
-const QString exampleString = qtTrId("example_internationalised_string_id");
-```
-
-In QML the qsTrId() function should be used. The semantics are identical to the qtTrId() function. An example of its use follows:
-```qml
-Button {
-    //: This text will be displayed in a button, which when clicked will quit the application.
-    //% "Quit"
-    text: qsTrId("example_application-bt-quit")
-    onClicked: Qt.quit()
-}
-```
-
-The qmake project (.pro) file must trigger lupdate to generate the translation files. For example:
-```qmake
-# translations
-TS_FILE = $$OUT_PWD/$$TARGET.ts
-EE_QM = $$OUT_PWD/$$TARGET_eng_en.qm
-
-ts.commands += lupdate $$PWD -ts $$TS_FILE
-ts.CONFIG += no_check_exist
-ts.output = $$TS_FILE
-ts.input = .
-
-ts_install.files = $$TS_FILE
-ts_install.path = /usr/share/translations/source
-ts_install.CONFIG += no_check_exist
-
-engineering_english.commands += lrelease -idbased $$TS_FILE -qm $$EE_QM
-engineering_english.CONFIG += no_check_exist
-engineering_english.depends = ts
-engineering_english.input = $$TS_FILE
-engineering_english.output = $$EE_QM
-
-engineering_english_install.path = /usr/share/translations
-engineering_english_install.files = $$EE_QM
-engineering_english_install.CONFIG += no_check_exist
-
-QMAKE_EXTRA_TARGETS += ts engineering_english
-PRE_TARGETDEPS += ts engineering_english
-INSTALLS += ts_install engineering_english_install
-```
-
-### Directionality
-
-Some locales have specific requirements for directionality of content. For example, in English-speaking locales, text and content should be laid out left-to-right and top-to-bottom, however in some other locales a different directionality is required (e.g., top-to-bottom then left-to-right, or right-to-left). Some content will also need to be mirrored (e.g., directional arrow images) when the layout is reversed.
-
-Applications should be written so that the layout is internationalised, by making use of the directionality support in Qt Quick, via the horizontalAlignment, layoutMirroring, layoutDirection, and effectiveLayoutDirection properties, and querying Qt.application.layoutDirection to determine which alignment to use at run-time (the value of which is determined from the layout direction defined in the currently active translation file).
+While not mandatory for making use of translations in an app or component, for more general info about the Sailfish OS localisation process, you may also find it interesting to refer to the [L10n section](/Develop/L10n/).
 
 ## Localisation
 
@@ -74,9 +26,9 @@ The people from a particular locale will often require the content they consume 
 
 ### Translations
 
-The first step in localisation is usually defining translations for every user-visible string in the application or UI. For core Sailfish OS components and applications, the [Sailfish OS Translation Tool](https://translate.sailfishos.org/) is used to define the translation strings. For more information about how to use that tool, please see the page on [Translating Sailfish OS](/Develop/L10n).
+The first step in localisation is usually defining translations for every user-visible string in the application or user interface. For core Sailfish OS components and applications, the [Sailfish OS Translation Tool](https://translate.sailfishos.org/) is used to define the translation strings. For more information about how to use that tool, please see the page on [Translating Sailfish OS](/Develop/L10n).
 
-The tool includes the translated string identifier, context description, and engineering english text, for every user-visible string in Sailfish OS. Translators can then contribute a new translation (or correction to an existing translation) for that string, for the localisation they wish to improve. The translation strings are added to the locale-specific catalogue which is then indexed at build time, which applications read from at run-time to display the appropriate translated string in the UI.
+The tool includes the translated string identifier, context description, and Engineering English text, for every user-visible string in Sailfish OS. Translators can then contribute a new translation (or correction to an existing translation) for that string, for the localisation they wish to improve. The translation strings are added to the locale-specific catalogue which is then indexed at build time, which applications read from at run-time to display the appropriate translated string in the user interface.
 
 The translation file will also define the layout directionality (e.g.: left-to-right and top-to-bottom; right-to-left and top-to-bottom; etc) required for that locale.
 
@@ -95,10 +47,10 @@ Different locales use different scripts for text content. These scripts must be 
   - Bokmål
   - Sanskrit
 
-#### Fonts
+### Fonts
 
 To support a variety of languages and scripts, the fonts used in the device must support the script used by the language. The standard font on Sailfish OS is called Sail Sans Pro, but other fonts are supported on the system and new fonts can be added to the font database when required.
 
-#### Directionality
+### Directionality
 
 Laying out text is a complicated process, involving kerning and ligatures. The directionality of text layout also affects this process, and is important that the application be localised appropriately with respect to content layout and directionality in order to ensure that the content is displayed appropriately.


### PR DESCRIPTION
Restructures the sections on Internationalisation to distinguish more clearly between Platform and Application configurations. Adds additional information (largely taken from our internal wiki) on best practice for how to handle internationalisation on Sailfish OS.