### PR TITLE
Shorten & rephrase two sentences into one

### DIFF
--- a/Support/Help_Articles/Flashing_Troubleshooting/README.md
+++ b/Support/Help_Articles/Flashing_Troubleshooting/README.md
@@ -91,9 +91,8 @@ Also, send the output from the terminal window showing how the execution of the 
 
 ## Can the Sailfish community help
 
-Our community has many talented persons, even experts. One of them has composed the following instructions for those struggling with Sailfish installation. 
-The article (read-only) is beyond this **[link](https://gitlab.com/Olf0/sailfishX#guide-installing-sailfishx-on-xperias)**.
-We/Jolla have not tested the tricks and methods of that article. They may or may not help. Following those instructions requires a fair amount of skills with Linux commands and computer systems, so we do not recommend them for beginners. Use them with care and at your own risk.
+Our community has many talented persons, even experts. One of them has composed extensive instructions for installing Sailfish&nbsp;X (**[link](https://gitlab.com/Olf0/sailfishX#guide-installing-sailfishx-on-xperias)**), which also cover troubleshooting. 
+We/Jolla have not tested the tricks and methods of that article. They may or may not help. Some of these instructions require a fair amount of skills with Linux commands and computer systems, so we do not recommend them for beginners. Use them with care and at your own risk.
 
 You can also search help or send questions to the **[Forum](https://forum.sailfishos.org/)**.
 


### PR DESCRIPTION
Originally I aimed at rectifying the "*(read-only)*" leftover from the former web-link to TJC (and missed in PR #157), plus the awkward phrase "beyond a link": At GitHub "Issues" and PRs are open, hence "read-only" does not fit.

Ultimately I ended up joining and shortening these two sentences, while trying to retain the style by linking only single words in bold.

Additionally I slightly altered the start of a later sentence to denote that different sections require varying skills.