### PR TITLE
Make the title of Backup-Restore match with permalink

### DIFF
--- a/Support/Help_Articles/Backup_and_Restore/README.md
+++ b/Support/Help_Articles/Backup_and_Restore/README.md
@@ -1,9 +1,9 @@
 ---
-title: Making Backup and Restoring It
+title: Backup and Restore
 permalink: Support/Help_Articles/Backup_and_Restore/
 parent: Help Articles
 layout: default
-nav_order: 80
+nav_order: 13
 ---
 
 


### PR DESCRIPTION
I want to modify the title of the document so that it would be similar to the permalink (folder path). Different names cause confusion.
Signed-off-by: Jorma Virkkunen <jorma.virkkunen@jolla.com>