### PR TITLE
Tips for SDK on Fedora 37

### DIFF
--- a/Tools/Sailfish_SDK/Installation/README.md
+++ b/Tools/Sailfish_SDK/Installation/README.md
@@ -79,6 +79,12 @@ In order to maintain compatibility with older Linux distributions, Sailfish SDK 
   - On Fedora the package ncurses-compat-libs must be installed
   - If you find no way to fix libtinfo.so.5 on your system, you may try creating it as a symbolic link to your system libncurses.so.5 (or even libncurses.so.6 or libtinfo.so.6)
 
+#### openssl 1.1 (Linux only)
+
+In order to maintain compatibility with older Linux distributions, Sailfish SDK links to this library, which may not be installed by default on more recent distributions:
+
+  - On Fedora the package openssl1.1 must be installed
+
 #### Modern bash
 
 _Sailfish SDK 3.7 and newer._

--- a/Tools/Sailfish_SDK/Known_Issues/README.md
+++ b/Tools/Sailfish_SDK/Known_Issues/README.md
@@ -54,6 +54,14 @@ These are the known issues with the Sailfish SDK. If you have any questions, fee
       - Sailfish IDE needs restart after changing SSH port of a Docker based build engine
       - Error starting the build engine on [Linux hosts with cgroups v2](https://forum.sailfishos.org/t/issues-with-installing-sailfish-sdk-docker-with-debian-bullseye-11/4454)
           - It is usually possible to revert back to cgroups v1 by adding `systemd.unified_cgroup_hierarchy=false` to the host kernel command line
+      - On some systems package manager gets stuck or crashes due to unreasonably high file descriptor limit and builds will not get past initialization phase. You may stop build engine with `sfdk engine stop` and then use this workaround:
+
+            sfdk engine exec sudo tee /etc/security/limits.d/95-nofile-sdk-fix.conf <<END
+            # This is a workaround for issues with package manager
+            * hard nofile 4096
+            root hard nofile 4096
+            END
+
 
 ### Sailfish OS Emulator
 


### PR DESCRIPTION
Add openssl 1.1 requirement to install instructions.

Add workaround for stuck builds to known issues.