### PR TITLE
Lock jekyll-sass-converter to version 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gemspec
 
 gem "bundler", "~> 2.3"
 gem "webrick", "~> 1.7"
+gem "jekyll-sass-converter", "2.2.0"


### PR DESCRIPTION
Version 3.0.0 breaks the build tests in our CI

