### PR TITLE
Use where for filtering Apps and MW subpages

### DIFF
--- a/Reference/Core_Areas_and_APIs/Apps_and_MW/README.md
+++ b/Reference/Core_Areas_and_APIs/Apps_and_MW/README.md
@@ -8,13 +8,10 @@ nav_order: 100
 ---
 
 <ul>
-{% assign sorted_pages = site.pages | sort:"title" %}
+{% assign sorted_pages = site.pages | where: "parent", "Apps and MW" | sort:"title" %}
 {% for item in sorted_pages %}
-  {% assign item_dir_parts = item.dir | remove_first: page.dir | split: '/' %}
-  {% if item.dir contains page.dir and item_dir_parts.size == 1 %}
     <li>
       <a href="{{ item.url }}">{{ item.title }}</a>
     </li>
-  {% endif %}
 {% endfor %}
 </ul>


### PR DESCRIPTION
Original code failed on Array comparison while sorting pges, most likely because array had pages with titles which could be interpreted as integers. Filtering the pages before sorting them fixes the issue, and also makes the filtering inside for loop redundant.