### PR TITLE
Corrections to i18n docs

### DIFF
--- a/Reference/I18n/README.md
+++ b/Reference/I18n/README.md
@@ -36,7 +36,7 @@ The translation file will also define the layout directionality (e.g.: left-to-r
 
 Different locales require different input methods. In some locales, a QWERTY-layout virtual keyboard is the most common input method, but other locales require different keyboard layouts, and in some locales the most common input method is hand-writing-recognition.
 
-Sailfish OS allows different input methods to be used on the device, including virtual keyboards, physical keyboards, virtual handwriting pads, and microphone input. The input method system used in Sailfish OS is [Maliit](https://github.com/sailfishos/maliit-framework) which provides an extensible plugin architecture, allowing third-party input method engines (such as from Nuance) to be installed into the system.
+Sailfish OS allows different input methods to be used on the device, including virtual keyboards, physical keyboards, virtual handwriting pads, and microphone input. The input method system used in Sailfish OS is [Maliit](https://github.com/sailfishos/maliit-framework) which provides an extensible plugin architecture.
 
 ### Scripts
 
@@ -44,8 +44,19 @@ Different locales use different scripts for text content. These scripts must be 
 
   - Latin
   - Cyrillic
-  - Bokmål
-  - Sanskrit
+  - Greek
+  - Kannada
+  - Gujarati
+  - Devanagari
+  - Bengali
+  - Telugu
+  - Tamil
+  - Punjabi
+  - Malayalam
+  - Traditional Chinese
+  - Simplified Chinese
+  - Thai
+  - Arabic
 
 ### Fonts
 


### PR DESCRIPTION
Bokmål and Sanskrit are languages, not scripts. Removed those and added the ones we have font support for. All except thai and arabic have also input support.

Removed also reference to Nuance being which hinted it being a Maliit plugin. That's incorrect, the jolla-keyboard is a maliit plugin and jolla-keyboard internally has pluggable support for using Nuange engine.

Signed-off-by: Pekka Vuorela <pekka.vuorela@jolla.com>