### PR TITLE
Link to forum wiki instead of mer wiki

### DIFF
--- a/Develop/HW_Adaptation/README.md
+++ b/Develop/HW_Adaptation/README.md
@@ -46,4 +46,4 @@ The hardware areas which need adapting are:
   - USB : Network/Charging
   - FM Radio
 
-The status of community adaptations to common devices are [recorded here](https://wiki.merproject.org/wiki/Adaptations/libhybris).
+The status of community adaptations to common devices are [recorded here](https://forum.sailfishos.org/t/community-hardware-adaptations/14081).


### PR DESCRIPTION
Since the merproject.org/wiki is down for some time now, change this link to forum too..