### PR TITLE
Updating Bluetooth Pairing document

### DIFF
--- a/Support/Help_Articles/Bluetooth_Pairing/README.md
+++ b/Support/Help_Articles/Bluetooth_Pairing/README.md
@@ -215,4 +215,11 @@ devel-su
 
 The paired device appears in the Bluetooth menu of your phone now.
 
+# Bluetooth profiles supported by Sailfish OS
+
+Sailfish OS supports the Bluetooth profiles listed on this [separate document](/Reference/Core_Areas_and_APIs/Networking/#bluetooth).
+
+
+
+
 


### PR DESCRIPTION
Added supported BT profiles in the end of the document. Decided to add link to the document  which already exists: https://docs.sailfishos.org/Reference/Core_Areas_and_APIs/Networking/#bluetooth
That document however could be at some point be updated so that some of the missing profiles will be added there.