### PR TITLE
Crosslinking diagnostic sections

### DIFF
--- a/Reference/Sailfish_OS_Cheat_Sheet/README.md
+++ b/Reference/Sailfish_OS_Cheat_Sheet/README.md
@@ -141,6 +141,10 @@ zypper remove --clean-deps PACKAGENAME
 
 ## Diagnostics
 
+
+
+Also see [this section](https://docs.sailfishos.org/Develop/Platform/Testing_Advic)
+
 Saving logs is always good
 ```nosh
 devel-su journalctl -a > ~/saved.journal

--- a/Reference/Sailfish_OS_Cheat_Sheet/README.md
+++ b/Reference/Sailfish_OS_Cheat_Sheet/README.md
@@ -143,7 +143,7 @@ zypper remove --clean-deps PACKAGENAME
 
 
 
-Also see [this section](https://docs.sailfishos.org/Develop/Platform/Testing_Advic)
+Also see [this section](/Develop/Platform/Testing_Advice)
 
 Saving logs is always good
 ```nosh


### PR DESCRIPTION
I just looked for the diagnostic commands and noticed there are multiple places where diagnostic commands are listed. As a quickfix i propose to link those to each other. The android support section should do this as well probably