### PR TITLE
Update README.md

### DIFF
--- a/Develop/Apps/Harbour/Allowed_APIs/README.md
+++ b/Develop/Apps/Harbour/Allowed_APIs/README.md
@@ -424,7 +424,7 @@ Usually you shouldn't add library depencencies or python module dependencies to 
   - python3dist(sortedcontainers)
   - python3dist(toml)
   - python3dist(twisted)
-  - python3dist(pillow)
+  - python3-imaging
     - While we allow Pillow, we make no quarantees of backwards compatibility between releases. Supported since Sailfish OS 4.5.0.
   - python3dist(pytz)
     - Supported since Sailfish OS 4.5.0


### PR DESCRIPTION
using python3-imaging will get into harbour. using pkconfig(pillow) will not.

I just tested this with a new release of Imageworks.