### PR TITLE
Update journald.conf rate limit throttling

### DIFF
--- a/Reference/Sailfish_OS_Cheat_Sheet/README.md
+++ b/Reference/Sailfish_OS_Cheat_Sheet/README.md
@@ -162,11 +162,15 @@ Storage=persistent
 
 By default, the systemd journal throttles output from particularly noisy processes, which can be frustrating when trying to debug an application. Preventing journald from throttling logging from a verbose process - edit /etc/systemd/journald.conf and set
 ```ini
-RateLimitBurst=9999
-RateLimitInterval=5s
+RateLimitBurst=0
+RateLimitInterval=0
 ```
 
-Which will cause systemd to throttle journal output from any process which emits more than 9999 lines of output in any five second interval NOTE: after doing changes for /etc/systemd/journald.conf you should reboot the device.
+After doing changes for /etc/systemd/journald.conf restart journald.
+
+```nosh
+devel-su systemctl restart systemd-journald
+```
 
 Various processes can be made more verbose by setting certain environment variables:
 ```nosh


### PR DESCRIPTION
Freedesktop Journald conf doc says that to turn off any kind of rate limiting, set either value to 0. Let's do so instead of using arbitrary values.

See also https://www.freedesktop.org/software/systemd/man/journald.conf.html#RateLimitIntervalSec=