### PR TITLE
Logging msyncd requires privileged access

### DIFF
--- a/Support/Help_Articles/Collecting_Logs/Collect_Synchronization_Logs/README.md
+++ b/Support/Help_Articles/Collecting_Logs/Collect_Synchronization_Logs/README.md
@@ -66,8 +66,7 @@ journalctl -a -b > journal-sync.txt
 2. The level of debugging enabled in step 2 of the Basic sync logs chapter does not make the system print out too much data on contact sync. If there is a need to get deeper insight to the issues in contact sync then consider using the following setup
 (make sure that you copy the whole long command):
 ```
-devel-su
-QTCONTACTS_SQLITE_TRACE=1 MSYNCD_LOGGING_LEVEL=8 msyncd 2>&1 | cat > msyncd.log
+sudo -E -g privileged QTCONTACTS_SQLITE_TRACE=1 MSYNCD_LOGGING_LEVEL=8 msyncd 2>&1 | cat > msyncd.log
 ```
 3. Trigger a sync cycle by opening up "Settings > Accounts". Then long-press the account you want to debug and tap Sync in the pop-up menu.
 4. Wait for 30 seconds or until the sync cycle has completed. The logs collected from the msyncd terminal were saved to file msyncd.log.


### PR DESCRIPTION
I'm currently debugging making a backup of my device to my Nextcloud server, and I tried to enable msyncd logging:

```text
systemctl --user stop msyncd
killall msyncd
devel-su
MSYNCD_LOGGING_LEVEL=8 msyncd 2>&1 | tee -a msyncd.log
```

I got these results:

```text
** (process:11987): WARNING **: 14:09:49.650: Could not stat accounts privilege directory
[W] unknown:0 - Manager could not be created. DB is locked

** (process:11987): CRITICAL **: 14:09:49.698: ag_manager_list: assertion 'AG_IS_MANAGER (manager)' failed
[W] unknown:0 - Profile not found
```

When I tried to make a backup, creating the backup failed immediately. I then tried running it as `defaultuser:privileged` like this:

```
sudo -E -g privileged MSYNCD_LOGGING_LEVEL=8 msyncd 2>&1 | tee -a msyncd.log
```

This resulted in no rows being printed - a good sign. I then tried to create a backup, which started, and eventually failed with a bunch of debug output (and hopefully something to help with my issue).

I'm not sure if using `sudo` is the preferred tool to use for this, but it let `msync` start as correct user and group, which seems to be required for this guide to work.