### PR TITLE
Update supported & unsupported devices on OS release 4.6

### DIFF
--- a/Support/Supported_Devices/README.md
+++ b/Support/Supported_Devices/README.md
@@ -5,35 +5,50 @@ layout: default
 nav_order: 200
 ---
 
-Status in February 2023: Jolla has ported Sailfish OS to the following phone models. Sailfish OS can be installed
-on the following devices. The table below corresponds to Sailfish OS version 4.5.0.
+SUPPORTED DEVICES
 
-One can purchase the Sailfish X licence and download an installable Sailfish OS image from [Jolla Shop](https://shop.jolla.com).
+Status on OS release 4.6: Sailfish OS has been ported to the following phone models.
+Sailfish licences and installable Sailfish OS images are available at [Jolla Shop](https://shop.jolla.com).
 
+| Device                     | Model               | Required stock Android version[^1]  | Kernel / BSP[^2] | AppSupport[^3] version /<br />API level[^4] | First Sailfish OS release        |
+| -------------------------- | ------------------- | :---------------------------------: | :--------------: | :-----------------------------------------: | :------------------------------: |
+| Xperia 10 V SIM+uSD+eSIM   | XQ-DC54             | Android 13<br />                    | 5.4 / 13         | NA/NA                                       | 4.6.0<br />Sauna<br />2024       |
+| Xperia 10 IV SIM+uSD+eSIM  | XQ-CC54             | Android 13<br />                    | 5.4 / 13         | -"-                                         | -"-                              |
+| Xperia 10 III Dual SIM     | XQ-BT52             | Android 11<br />(12 is ok)          | 4.19 / 11        | 11 / 30                                     | 4.4.0<br />Vanha Rauma<br />2022 |
+| Xperia 10 II Single SIM    | XQ-AU51             | Android 11<br />(10 is ok)          | 4.14 / 10        | -"-                                         | 4.1.0<br />Kvarken<br />2021     |
+| Xperia 10 II Dual SIM      | XQ-AU52             | -"-                                 |   -"-            | -"-                                         | -"-                              |
+| Xperia 10 Single SIM       | I3113, I3123        | Android 9 <br />(do not use 10)     | 4.9 /  9         | -"-                                         | 3.2.0<br />Torronsuo<br />2019   |
+| Xperia 10 Dual SIM         | I4113, I4193        | -"-                                 |   -"-            | -"-                                         | -"-                              | 
+| Xperia 10 Plus Single SIM  | I3213, I3223        | -"-                                 |   -"-            | -"-                                         | -"-                              |
+| Xperia 10 Plus Dual SIM    | I4213, I4293        | -"-                                 |   -"-            | -"-                                         | -"-                              |
+| Xperia XA2 Single SIM      | H3113, H3123, H3133 | Android 9                           | 4.4 / 8.1        | -"-                                         | 3.0.0<br />Lemmenjoki<br />2018  |
+| Xperia XA2 Dual SIM        | H4113, H4133        | -"-                                 |   -"-            | -"-                                         | -"-                              |
+| Xperia XA2 Plus Single SIM | H3413               | -"-                                 |   -"-            | -"-                                         | -"-                              |
+| Xperia XA2 Plus Dual SIM   | H4413, H4493        | -"-                                 |   -"-            | -"-                                         | -"-                              |
+| Xperia XA2 Ultra Single S. | H3213, H3223        | -"-                                 |   -"-            | -"-                                         | -"-                              |
+| Xperia XA2 Ultra Dual SIM  | H4213, H4233        | -"-                                 |   -"-            | -"-                                         | -"-                              |
 
-| Device                     | Model               | Required stock Android version[^1]  | Kernel / BSP[^2] | AppSupport[^3] version /<br />API Level[^4] | First Sailfish OS release |
-| -------------------------- | ------------------- | :---------------------------------: | :--------------: | :----------------------------------------:  | ------------------------- |
-| Xperia 10 III Dual SIM     | XQ-BT52             | Android 11<br />(12 is ok)          | 4.19 / 11        | 11 / 30                                     | 4.4.0<br />Vanha Rauma    |
-| Xperia 10 II Single SIM    | XQ-AU51             | Android 11<br />(10 is ok)          | 4.14 / 10        | -"-                                         | 4.1.0<br />Kvarken        |
-| Xperia 10 II Dual SIM      | XQ-AU52             | -"-                                 |   -"-            | -"-                                         | -"-                       |
-| Xperia 10 Single SIM       | I3113, I3123        | Android 9 <br />(do not use 10)     | 4.9 /  9         | -"-                                         | 3.2.0<br />Torronsuo      |
-| Xperia 10 Dual SIM         | I4113, I4193        | -"-                                 |   -"-            | -"-                                         | -"-                       | 
-| Xperia 10 Plus Single SIM  | I3213, I3223        | -"-                                 |   -"-            | -"-                                         | -"-                       |
-| Xperia 10 Plus Dual SIM    | I4213, I4293        | -"-                                 |   -"-            | -"-                                         | -"-                       |
-| Xperia XA2 Single SIM      | H3113, H3123, H3133 | Android 9                           | 4.4 / 8.1        | -"-                                         | 3.0.0<br />Lemmenjoki     |
-| Xperia XA2 Dual SIM        | H4113, H4133        | -"-                                 |   -"-            | -"-                                         | -"-                       |
-| Xperia XA2 Plus Single SIM | H3413               | -"-                                 |   -"-            | -"-                                         | -"-                       |
-| Xperia XA2 Plus Dual SIM   | H4413, H4493        | -"-                                 |   -"-            | -"-                                         | -"-                       |
-| Xperia XA2 Ultra Single S. | H3213, H3223        | -"-                                 |   -"-            | -"-                                         | -"-                       |
-| Xperia XA2 Ultra Dual SIM  | H4213, H4233        | -"-                                 |   -"-            | -"-                                         | -"-                       |
-| Xperia X Single SIM        | F5121               | Android 8                           | 3.10 / 6         | 4.4.4 / 19                                  | 2.1.2<br />Kiiminkijoki   |
-| Xperia X Dual SIM          | F5122               | -"-                                 |   -"-            | -"-                                         | -"-                       |
-| Gemini PDA                 | X25                 | (NA)                                |  3.18 / 7        | N/A                                         | 3.0.2<br />Oulanka        |
-| Gemini PDA                 | X27                 | (NA)                                |  3.18 / 7        | N/A                                         | -"-                       |
-| Jolla Tablet               |                     | (NA)                                |  3.10 / 4.4.4    | 4.4.4 / 19                                  | (NA)                      |
-| Jolla C                    |                     | (NA)                                |  3.10 / 5        | 4.4.4 / 19                                  | (NA)                      |
 
 [^1]: **Required stock Android version** : The Android version of a phone (shown in the "About phone" menu) before flashing Sailfish OS to it.
 [^2]: **BSP**                            : BSP = Board Support Package, Android drivers prepared for certain Android version.
-[^3]: **AppSupport**                     : AppSupport is the sales name of the Android runtime environment of Sailfish OS
+[^3]: **AppSupport**                     : AppSupport is the sales name of the Android runtime environment of Sailfish OS.
 [^4]: **API Level**                      : The version of Android API implemented into AppSupport.
+
+
+UNSUPPORTED DEVICES
+
+The following devices are not supported any more after OS release 4.6:
+
+
+| Device               | Model       | First Sailfish OS release           | Last Sailfish OS release                 |
+| -------------------- | ----------- | :---------------------------------: | :--------------------------------------: |
+| Gemini PDA           | X25         | 3.0.2<br />Oulanka<br />2019        | 4.6.0<br />Sauna<br />2024               |
+| Gemini PDA           | X27         | -"-                                 | -"-                                      |
+| Xperia X Single SIM  | F5121       | 2.1.2<br />Kiiminkijoki<br />2017   | -"-                                      |
+| Xperia X Dual SIM    | F5122       | -"-                                 | -"-                                      |
+| Jolla C              | JP-1601     | 2.0.2<br />Aurajoki<br />2016       | -"-                                      |
+| Jolla Tablet         | JT-1501     | 1.1.9<br />Eineheminlampi<br />2015 | -"-                                      |
+| Jolla Phone          | JP-1301     | 1.0.0<br />Kaajanlampi<br />2013    | 3.4.0<br />Pallas-Yllästunturi<br />2020 |
+
+
+


### PR DESCRIPTION
I have added Xperia 10 IV and Xperia 10 V to the list of supported devices. AppSupport is N/A at this point.
Secondly, I have created a new table for unsupported devices. It shows the first and the last OS release for each device.
