### PR TITLE
Correct AppSupport removal instructions

### DIFF
--- a/Support/Help_Articles/Android_App_Support/Removing_Android_App_Support/README.md
+++ b/Support/Help_Articles/Android_App_Support/Removing_Android_App_Support/README.md
@@ -7,19 +7,27 @@ layout: default
 nav_order: 500
 ---
 
-This document instructs how to revert a Sailfish device back to a state where there is no Android Support and no Android apps.
+This document instructs how to revert a Sailfish device back to a state where there is no Android AppSupport and no Android apps. Alternatively, it is possible to remove the AppSupport but no Android apps or not all of them, allowing to reinstall the AppSupport.
 
 
 # Clean removal
 
-Android App SUpport should be removed in this way. It is to remove everything necessary.
+This is the recommended way of removing the Android AppSupport. It is to remove everything necessary but you can optionally keep the installed Android apps or some of them.
 
-1) Uninstall all Android apps, one by one, using the app launcher grid. 
+1) Uninstall all Android apps installed from the Jolla Store
+* Jolla Store has the following Android apps: _F-Droid_, _Aptoide_ and _Here WeGo_ (2024 July).
+* These apps **must** be uninstalled before uninstalling the AppSupport due to some dependency issues. AppSupport cannot be fully uninstalled without doing this step.
+* Open the Jolla Store. Pull down My Apps.
+* Look for the 3 apps mentioned above. Long-tap one at a time and select “Uninstall”.
+
+2) Uninstall your Android apps installed from other app stores
+* Open the app launcher grid
 * Tap and hold the background until all icons get an X on them
-* Uninstall Android apps by tapping each of them
-  
-2) Uninstall Android AppSupport:
-* Open Jolla Store app on your phone
+* Uninstall all or selected Android apps by tapping the X on each of them
+* If you do not remove an Android app here, it will persist over the removal and reinstallation of AppSupport (the icons are hidden when AppSupport has been removed).
+
+3) Uninstall Android AppSupport
+* Open the Jolla Store app on your phone
 * Pull down My Apps
 * Look for "Android AppSupport"
 * Long-tap it and select "Uninstall"
@@ -32,10 +40,24 @@ Android App SUpport should be removed in this way. It is to remove everything ne
   </span>
 </div>
 
+4) Check that it worked (optional)
+* Open the Terminal app
+* Issue the command
 
-3) Restart the device.
+```
+rpm -qa |grep -E "alien|apkd|appsupport"
+```
+* If the command printed just the following one line, AppSupport was successfully removed:
 
-_This is the recommended way. It is expected to work correctly on Sailfish 4 releases and thereafter._
+```
+feature-alien-0.4.2-1.2.3.jolla.aarch64
+```
+(please ignore the version)
+
+5) Restart the device
+
+If you want to keep using AppSupport, open the Jolla Store again and install AppSupport. Remember to start it in “Settings > System > Android AppSupport”. After this, all Android apps that you did not uninstall (at step 2) will reappear at the app grid.
+
 
 # Brutal way
 
@@ -48,13 +70,11 @@ The commands below will definitely and quickly remove all Android stuff. Use it 
 * Look for "Android AppSupport"
 * Long-tap it and select "Uninstall" (see the picture above)
   
-2) Run the following commands in the Terminal:
+2) Run the following commands in the Terminal. Note that they remove all of your installed Android apps and their data, too, in addition to AppSupport.
 ```
 devel-su
-cd /home/defaultuser          ## On some phones:  cd /home/nemo
-rm -rf /home/.android/*
-rm -rf android_storage
-reboot
+rm -rf /home/.android/
+rm -rf /home/defaultuser/android_storage/   ## On some phones: /home/nemo/android_storage/
 ```
 3) Restart the device.
 


### PR DESCRIPTION
Two issues handled here:
1) The Android apps available in the Jolla Store (rpm wrapped) must be uninstalled before AppSupport can be removed. A dependency issue "WONTFIX", says our R&D.
2) There was a Linux grammar mistake in one of the rm commands leaving a flag file undeleted. This prevented starting the reinstalled AppSupport.