### PR TITLE
Update wordings

### DIFF
--- a/Support/Help_Articles/Managing_Sailfish_OS/Updating_Sailfish_OS/README.md
+++ b/Support/Help_Articles/Managing_Sailfish_OS/Updating_Sailfish_OS/README.md
@@ -290,7 +290,7 @@ Now, open either the Terminal app or the Putty terminal.   Issue the following
 ```
 cd $HOME
 devel-su     ###  you will need to type your SSH password here
-pkill store-client  
+pkill -f osupdateservice
 rm -rf /home/.pk-zypp-dist-upgrade-cache/*  
 rm -rf ./.cache/sailfish-osupdateservice/os-info  
 reboot
@@ -368,7 +368,7 @@ Delete the reminders of earlier failing OS update attempts to make a clean updat
 ```
 cd $HOME  
 devel-su  
-pkill  store-client
+pkill -f osupdateservice
 rm -rf /home/.pk-zypp-dist-upgrade-cache/*
 rm ./.cache/sailfish-osupdateservice/os-info
 exit
@@ -385,7 +385,7 @@ The OS update notification may persist in the device after updating the OS with 
 ```
 cd $HOME  
 devel-su  
-pkill store-client
+pkill -f osupdateservice
 rm ./.cache/sailfish-osupdateservice/os-info
 ```
 

--- a/Support/Help_Articles/Managing_Sailfish_OS/Updating_Sailfish_OS/README.md
+++ b/Support/Help_Articles/Managing_Sailfish_OS/Updating_Sailfish_OS/README.md
@@ -148,7 +148,7 @@ reboot                 ## Restart device
 **(*)** NOTE: Use the next stop release counted from the current OS version of your phone. You must traverse through all stop releases, and only after the last one of them you can "version dup" to the latest OS version. Otherwise, there is a great risk of breaking your device.
 
 Q: What is my next stop release?
-A: Check the current OS version of your device in "_Settings > About product_" (or "_Settings > Info > About product_" on some very old Sailfish 1 releases). Then look at the **[list of stop releases](https://docs.sailfishos.org/Support/Releases/)**. If your current version is let's say 1.1.6, then the next stop release would be 1.1.7.28. Note that only the top-most one on each table row is a stop release. For instance, 4.5.0.25 is a stop release but 4.5.0.24 is not.
+A: Check the current OS version of your device in "_Settings > About product_" (or "_Settings > Info > About product_" on some very old Sailfish 1 releases). Then look at the **[list of stop releases](https://docs.sailfishos.org/Support/Releases/)**. If your current version is let's say 1.1.6, then the next stop release would be 1.1.7.28. Note that you only need to go through the top-most one on each table row. For instance, from 4.4 you can update to 4.5.0.25 without first going to 4.5.0.24.
 
 Q: If I have OS version **1.0.0.5** on my device which steps do I need to take to update it to the latest version?
 A: Unfortunately, all of the following:


### PR DESCRIPTION
One commit for suggesting killing the proper update service.

One  commit for adjusting stop-release wording which was reported confusing. We don't need to go into philosophical questions whether a stop-release can become non-stop-release if there's a later minor version from the same major release.