### PR TITLE
Suggest modifications only to .bashrc

### DIFF
--- a/Tools/Platform_SDK/Installation/README.md
+++ b/Tools/Platform_SDK/Installation/README.md
@@ -19,11 +19,10 @@ curl -k -O https://releases.sailfishos.org/sdk/installers/latest/Jolla-latest-Sa
 sudo mkdir -p $PLATFORM_SDK_ROOT/sdks/sfossdk
 sudo tar --numeric-owner -p -xjf Jolla-latest-SailfishOS_Platform_SDK_Chroot-i486.tar.bz2 -C $PLATFORM_SDK_ROOT/sdks/sfossdk
 echo "export PLATFORM_SDK_ROOT=$PLATFORM_SDK_ROOT" >> ~/.bashrc
-echo 'alias sfossdk=$PLATFORM_SDK_ROOT/sdks/sfossdk/sdk-chroot' >> ~/.bashrc; exec bash
-echo 'if [[ $SAILFISH_SDK ]]; then' >> ~/.bash_profile
-echo '  PS1="PlatformSDK $PS1"' >> ~/.bash_profile
-echo '  [ -d /etc/bash_completion.d ] && for i in /etc/bash_completion.d/*;do . $i;done' >> ~/.bash_profile
-echo 'fi' >> ~/.bash_profile
+echo 'alias sfossdk=$PLATFORM_SDK_ROOT/sdks/sfossdk/sdk-chroot' >> ~/.bashrc
+echo 'if [[ $SAILFISH_SDK ]]; then' >> ~/.bashrc
+echo '  PS1="PlatformSDK $PS1"' >> ~/.bashrc
+echo 'fi' >> ~/.bashrc; exec bash
 sfossdk
 ```
 
@@ -104,17 +103,11 @@ As mentioned, the Sailfish Platform SDK is location independent so it uses the l
 
 ## Entering Sailfish Platform SDK
 
-Before entering the Sailfish Platform SDK you may want to make changes to your ".bash_profile" file to give you a nice prompt to remind you that you are in the Sailfish Platform SDK. This also reads the bash autocompletion scripts from inside the chroot.
+Before entering the Sailfish Platform SDK you may want to make changes to your ".bashrc" file to give you a nice prompt to remind you that you are in the Sailfish Platform SDK.
 ```nosh
-cat << EOF >> ~/.bash_profile
+cat << EOF >> ~/.bashrc
 if [[ $SAILFISH_SDK ]]; then
   PS1="PlatformSDK \$PS1"
-  if [ -d /etc/bash_completion.d ]; then
-    for i in /etc/bash_completion.d/*;
-    do
-      . \$i
-    done
-  fi
 fi
 EOF
 ```


### PR DESCRIPTION
Looks like current Ubuntu is having a .profile file in skel instead of .bash_profile with some detection of current shell. Then with .bash_profile created by SDK instructions, bash stops then reading the default .profile which had e.g. sourcing of .bashrc file.

So let's instead just suggest modifications to .bashrc.

Removed bash completion as there's not much to complete. Keeps the setup simpler.