### PR TITLE
Add Jolla C2 and link to community ports

### DIFF
--- a/Support/Supported_Devices/README.md
+++ b/Support/Supported_Devices/README.md
@@ -5,9 +5,9 @@ layout: default
 nav_order: 200
 ---
 
-Status regarding Sailfish OS version 4.6.0:
+Support status on Sailfish OS version 5.0.0:
 * Jolla has ported Sailfish OS to and supports the phone models listed in the table SUPPORTED DEVICES.
-* The last 4.6.0 update(s) (after 4.6.0.13) contain(s) the free trial version of Sailfish OS for the Xperia models XQ-CC54 and XQ-DC54. Android AppSupport is not yet available.
+* Sailfish OS release 4.6.0.15 contains the free trial version of Sailfish OS for the Xperia models XQ-CC54 and XQ-DC54. Android AppSupport is not yet available.
 
 
 SUPPORTED DEVICES
@@ -15,9 +15,10 @@ SUPPORTED DEVICES
 Sailfish licences and installable Sailfish OS images are available at [Jolla Shop](https://shop.jolla.com). However, there is no licence for the Xperia 10 IV (XQ-CC54) and 10 V (XQ-DC54) yet. Their free trial images can be downloaded from the [4.6.0 image folder](https://releases.sailfishos.org/images/).
 
 
-| Device                     | Model               | Required stock Android version[^1]  | Kernel / BSP[^2] | AppSupport[^3] /<br />API level[^4] | First Sailfish OS release        |
+| Device                     | Model               | Required stock Android version[^1]  | Kernel / BSP[^2] | AppSupport[^3] /<br />API level[^4]         | First Sailfish OS release        |
 | -------------------------- | ------------------- | :---------------------------------: | :--------------: | ------------------------------------------- | -------------------------------- |
-| Xperia 10 V SIM+uSD+eSIM   | XQ-DC54             | Android 13<br />(14 is ok)          | 5.4 / 14         | NA / NA                                     | 4.6.0<br />Sauna<br />2024       |
+| Jolla C2                   | S19 Max Pro S       | N/A                                 | 5.4 / 13         | 13 / 33                                     | 5.0.0<br />Tampella<br />2025    |
+| Xperia 10 V SIM+uSD+eSIM   | XQ-DC54             | Android 13<br />(14 is ok)          | 5.4 / 14         | 13 / 33                                     | 4.6.0<br />Sauna<br />2024       |
 | Xperia 10 IV SIM+uSD+eSIM  | XQ-CC54             | Android 13<br />(14 is ok)          | 5.4 / 14         | -"-                                         | 4.6.0<br />Sauna<br />2024       |
 | Xperia 10 III Dual SIM     | XQ-BT52             | Android 11<br />(12 is ok)          | 4.19 / 11        | 11 / 30                                     | 4.4.0<br />Vanha Rauma<br />2022 |
 | Xperia 10 II Single SIM    | XQ-AU51             | Android 11<br />(10 is ok)          | 4.14 / 10        | -"-                                         | 4.1.0<br />Kvarken<br />2021     |
@@ -52,5 +53,10 @@ DEVICES WE HAVE CEASED TO SUPPORT
 | Jolla Tablet         | JT-1501     | 1.1.9<br />Eineheminlampi<br />2015 | -"-                                      |
 | Jolla Phone          | JP-1301     | 1.0.0<br />Kaajanlampi<br />2013    | 3.4.0<br />Pallas-Yllästunturi<br />2020 |
 
+
+COMMUNITY PORTS
+
+The table [Community Hardware Adaptations](https://forum.sailfishos.org/t/community-hardware-adaptations/14081) contains a list of devices to which our Community has ported Sailfish OS to.
+These community ports expand the choice of Sailfish devices. However, they are not supported by Jolla Mobile Ltd and there is no Sailfish licence for them.
 
 


### PR DESCRIPTION
Jolla C2 was missing from the list of supported devices.
A link to community hardware adaptations was added, too.