### PR TITLE
Fix signing instructions

### DIFF
--- a/Develop/Apps/Packaging/Signing_Packages/README.md
+++ b/Develop/Apps/Packaging/Signing_Packages/README.md
@@ -24,7 +24,7 @@ The tool will ask all the necessary information. When unsure, select the default
 If your gpg key is protected with a passphrase, you need to provide it to the sfdk tool via passphrase file. This is just a text file containing the passphrase. The permissions of the file should be 600, so that it’s not readable by anyone else. In the example below, we use a file called `passphrase.txt`, located in user's home directory. You can use a file/path of your own choosing instead.
 
 ```
-$ echo “This is my passphrase” > $HOME/passphrase.txt
+$ echo "This is my passphrase" > $HOME/passphrase.txt
 $ chmod 0600 $HOME/passphrase.txt
 ```
 
@@ -33,8 +33,8 @@ $ chmod 0600 $HOME/passphrase.txt
 The `sfdk` tool supports signing packages as part of the build process. First we need to configure the tool to use our key and passphrase file:
 
 ```
-$ sfdk config package.signing.user=”Full Name” # replace Full Name with the name given when creating the signing key
-$ sfdk config package.signing-passphrase-file=$HOME/passphrase.txt
+$ sfdk config --global --push package.signing.user "Full Name" # replace Full Name with the name given when creating the signing key
+$ sfdk config --global --push package.signing-passphrase-file $HOME/passphrase.txt
 ```
 Then we can build the package with the `--sign` parameter:
 ```
@@ -60,7 +60,7 @@ RPMS/mypackage-0-1.noarch.rpm: digests signatures OK
 However, you will likely get `digests SIGNATURES NOT OK` when you first try it. This is because the key used for signing is not known to `rpm`. You must import the key to the rpm keyring first:
 
 ```
-$ gpg --output keyfile.gpg --armor --export “Full Name”
+$ gpg --output keyfile.gpg --armor --export "Full Name"
 
 $ rpm --import keyfile.gpg
 ```


### PR DESCRIPTION
Remove silly-quotes and fix config syntax.

Also `package.signing-passphrase` should be mentioned, but it appears to be broken.
