### PR TITLE
Warn about truncated data in CSV calendar export

### DIFF
--- a/Support/Help_Articles/Calendar/Calendar_Exporting_Data/README.md
+++ b/Support/Help_Articles/Calendar/Calendar_Exporting_Data/README.md
@@ -106,7 +106,7 @@ sqlite> select * from Components;
 sqlite> .quit 
 ```
 
-Note that when using sqlite3 version 3.52 or later you should use `.mode csv --limits off` to prevent long values (e.g., a detailed Description field) from being truncated. In versions 3.51 and earlier this option was neither necessary nor available, [values were not truncated by default prior to version 3.52](https://web.archive.org/web/20260520190538/https://sqlite.org/climode.html#default_output_formats).
+Note that if you are using sqlite3 version 3.52+ on a computer you should use `.mode csv --limits off` to prevent long values (e.g., a detailed Description field) from being truncated in the CSV output. This is *not* necessary when exporting to CSV on your phone in the current version of Sailfish OS, though.
 
 ## Collect the resulting file
 

--- a/Support/Help_Articles/Calendar/Calendar_Exporting_Data/README.md
+++ b/Support/Help_Articles/Calendar/Calendar_Exporting_Data/README.md
@@ -106,6 +106,8 @@ sqlite> select * from Components;
 sqlite> .quit 
 ```
 
+Note that when using sqlite3 version 3.52 or later you should use `.mode csv --limits off` to prevent long values (e.g., a detailed Description field) from being truncated. In versions 3.51 and earlier this option was neither necessary nor available, [values were not truncated by default prior to version 3.52](https://web.archive.org/web/20260520190538/https://sqlite.org/climode.html#default_output_formats).
+
 ## Collect the resulting file
 
 Move file `calendars.csv` from your Sailfish OS device to a computer where you have LibreOffice Calc (or a corresponding spreadsheet app).  Open the CSV file with that app.


### PR DESCRIPTION
Hi,

I noticed that since the recent sqlite v3.52 release it's possible for long values to be truncated when exporting the calendar to CSV. This PR adds a warning about this behavior to the docs.

Cheers,
Martin