### PR TITLE
Improve create-bundle.sh to allow arguments

### DIFF
--- a/create-bundle.sh
+++ b/create-bundle.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 bundle config set --local path 'vendor/bundle'
 bundle install
-bundle exec jekyll serve
+exec bundle exec jekyll serve $@


### PR DESCRIPTION
Give any extra arguments to jekyll and use exec to leave the shell as we don't need it afterwards. This is mainly to let me use `--incremental` for faster build times.