### PR TITLE
Fix Sony developerworld links

### DIFF
--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_11_Build_and_Flash/README.md
@@ -237,7 +237,7 @@ Known issues:
 
 ### Contributing to Sony AOSP
 
-If you want to help out with underlying issues in AOSP (fixing those will also fix them in SFOS, magic!:), follow this guide to build an AOSP 11 image: <https://developer.sony.com/open-source/aosp-on-xperia-open-devices/guides/aosp-build-instructions/build-aosp-android-11-0/>
+If you want to help out with underlying issues in AOSP (fixing those will also fix them in SFOS, magic!:), follow this guide to build an AOSP 11 image: <https://opendevices.sony.net/open-source/aosp-on-xperia-open-devices/guides/aosp-build-instructions/build-aosp-android-11-0/>
 
 Use this script to flash the AOSP images (the above website is pending an update for that step):
 

--- a/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_13_Build_and_Flash/README.md
+++ b/Develop/HW_Adaptation/Sailfish_X_Xperia_Android_13_Build_and_Flash/README.md
@@ -263,7 +263,7 @@ Known issues:
 ### Contributing to Sony AOSP
 
 If you want to help out with underlying issues in AOSP (fixing those will also fix them in SFOS, magic!:), follow this guide to build an AOSP 13 image:
-<https://developer.sony.com/open-source/aosp-on-xperia-open-devices/guides/aosp-build-instructions/build-aosp-android-13/>
+<https://opendevices.sony.net/open-source/aosp-on-xperia-open-devices/guides/aosp-build-instructions/build-aosp-android-13/>
 
 Use this script to flash the AOSP images (the above website is pending an update for that step):
 

--- a/Support/Help_Articles/Managing_Sailfish_OS/Reinstalling_Sailfish_OS/README.md
+++ b/Support/Help_Articles/Managing_Sailfish_OS/Reinstalling_Sailfish_OS/README.md
@@ -32,9 +32,9 @@ However, if your Xperia cannot use the services of cellular network properly (or
 
 ## Getting Emma and connecting Xperia to it
 
-Reverting Xperia device back to Android can be performed by the **[Emma](https://developer.sony.com/open-source/aosp-on-xperia-open-devices/get-started/flash-tool)** flashing tool from Sony. Emma runs on **Windows PC** only. It does not work on Linux or Mac computers.
+Reverting Xperia device back to Android can be performed by the **[Emma](https://opendevices.sony.net/open-source/aosp-on-xperia-open-devices/get-started/flash-tool)** flashing tool from Sony. Emma runs on **Windows PC** only. It does not work on Linux or Mac computers.
 
-1. Download and install the Flash tool “Emma”  from **[Sony’s developer website](https://developerworld.wpp.developer.sony.com/file/download/download-the-flash-tool/)** to your Windows computer.
+1. Download and install the Flash tool “Emma”  from **[Sony’s developer website](https://developerworld.wpp.opendevices.sony.net/file/download/download-the-flash-tool/)** to your Windows computer.
 2. Turn off your Xperia device. Leave it off for at least fifteen (15) seconds to be sure it is off.
 3. Hold down the **Volume Down** button on the device while connecting your device to your computer with a USB **data** cable. The LED next to the speaker on the device should soon turn from red to **green** (not blue).
 4. Run the Emma tool. A view similar to that in [Picture 1](#picture_1) should appear. It shows the phone model on the left. 

--- a/Support/Help_Articles/Managing_Sailfish_OS/Reinstalling_Sailfish_OS/README.md
+++ b/Support/Help_Articles/Managing_Sailfish_OS/Reinstalling_Sailfish_OS/README.md
@@ -34,7 +34,7 @@ However, if your Xperia cannot use the services of cellular network properly (or
 
 Reverting Xperia device back to Android can be performed by the **[Emma](https://opendevices.sony.net/open-source/aosp-on-xperia-open-devices/get-started/flash-tool)** flashing tool from Sony. Emma runs on **Windows PC** only. It does not work on Linux or Mac computers.
 
-1. Download and install the Flash tool “Emma”  from **[Sony’s developer website](https://developerworld.wpp.opendevices.sony.net/file/download/download-the-flash-tool/)** to your Windows computer.
+1. Download and install the Flash tool “Emma”  from **[Sony’s developer website](https://opendevices.sony.net/aosp-on-xperia-open-devices/get-started/flash-tool/download-the-flash-tool)** to your Windows computer.
 2. Turn off your Xperia device. Leave it off for at least fifteen (15) seconds to be sure it is off.
 3. Hold down the **Volume Down** button on the device while connecting your device to your computer with a USB **data** cable. The LED next to the speaker on the device should soon turn from red to **green** (not blue).
 4. Run the Emma tool. A view similar to that in [Picture 1](#picture_1) should appear. It shows the phone model on the left. 

--- a/Support/Help_Articles/Managing_Sailfish_OS/Updating_Vendor_Image/README.md
+++ b/Support/Help_Articles/Managing_Sailfish_OS/Updating_Vendor_Image/README.md
@@ -48,7 +48,7 @@ fastboot flash oem_a <filename>
 
 ## Example: Xperia XA2
 
-1. Download the zipped vendor image file **[v17B](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile/)** to your Sailfish OS flashing directory.
+1. Download the zipped vendor image file **[v17B](https://opendevices.sony.net/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile/)** to your Sailfish OS flashing directory.
 It has the name "SW_binaries_for_Xperia_Android_8.1.6.4_r1_v17B_nile.zip".
 2. Unzip it there. The resulting file is "SW_binaries_for_Xperia_Android_8.1.6.4_r1_v17_nile.img"
 3. Connect your XA2 to a **USB2** port.
@@ -75,7 +75,7 @@ Downgrading the vendor image goes in the same way as upgrading - see chapter [Up
 
 ## Example: Xperia XA2
 
-You may want to return to the v16 image on the Xperia XA2. Download the **[v16 image file](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/)**.
+You may want to return to the v16 image on the Xperia XA2. Download the **[v16 image file](https://opendevices.sony.net/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/)**.
 
 The command to flash it is this: 
 ```

--- a/Support/Help_Articles/WLAN_Troubleshooting/README.md
+++ b/Support/Help_Articles/WLAN_Troubleshooting/README.md
@@ -91,7 +91,7 @@ While the wireless setup wizard still allows to choose WEP as an encryption sche
 If the WiFi access point device is in your control, you should upgrade it to use **WPA2**.
 
 # Xperia XA2 and the 5 GHz frequency band
-With version **[v17B](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile)** of the Sony vendor image, we have observed a decrease in the perceived signal strength of the 5GHz WLAN access points. Version **[v16](https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/)** should work better in this respect. Therefore we would not recommend flashing v17B if you use WLAN networks in the 5GHz band.
+With version **[v17B](https://opendevices.sony.net/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile)** of the Sony vendor image, we have observed a decrease in the perceived signal strength of the 5GHz WLAN access points. Version **[v16](https://opendevices.sony.net/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/)** should work better in this respect. Therefore we would not recommend flashing v17B if you use WLAN networks in the 5GHz band.
 
 Our flashing script allows you to use either of the two versions. You can change the vendor image later by reflashing just the vendor image of your choice (and not Sailfish OS) by following the instructions **[here](/Support/Help_Articles/Updating_Vendor_Image/)**.
 

--- a/Support/Releases/Known_Issues/README.md
+++ b/Support/Releases/Known_Issues/README.md
@@ -167,7 +167,7 @@ Disabled
         </tr>
         <tr>
           <td>Xperia XA2</td>
-          <td>With <a href="https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile">v17B Sony vendor image</a> we observed a decrease in the perceived signal strength of the 5 GHz WLAN access points (investigations ongoing). Version <a href="https://developer.sony.com/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/">v16</a> works better in this respect. Therefore we would not recommend flashing v17B for the time being if you use WLAN networks in the 5 GHz band. You can reflash the vendor image of your choice by following the instructions <a href="/Support/Help_Articles/Updating_Vendor_Image/"> in here</a>.</td>
+          <td>With <a href="https://opendevices.sony.net/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile">v17B Sony vendor image</a> we observed a decrease in the perceived signal strength of the 5 GHz WLAN access points (investigations ongoing). Version <a href="https://opendevices.sony.net/file/download/software-binaries-for-aosp-oreo-android-8-1-kernel-4-4-nile-v16/">v16</a> works better in this respect. Therefore we would not recommend flashing v17B for the time being if you use WLAN networks in the 5 GHz band. You can reflash the vendor image of your choice by following the instructions <a href="/Support/Help_Articles/Updating_Vendor_Image/"> in here</a>.</td>
           <td></td>
           <td>Not planned</td>
         </tr>


### PR DESCRIPTION
The website has moved.

I have not verified each new link, but the paths seem to have stayed roughly the same.

